### PR TITLE
Add recipes for GStreamer 1.14 on meta-tegra

### DIFF
--- a/recipes-multimedia/gstreamer-base/files/0001-connect-has-a-different-signature-on-musl.patch
+++ b/recipes-multimedia/gstreamer-base/files/0001-connect-has-a-different-signature-on-musl.patch
@@ -1,0 +1,38 @@
+From 0bd8004d8dddc486d3961a5316d24e8f2645e4c8 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Sun, 9 Sep 2018 17:38:10 -0700
+Subject: [PATCH] connect has a different signature on musl
+
+On linux when not using glibc and using musl for C library, connect
+API has a different signature, this patch fixes this so it can compile
+on musl, the functionality should remain same as it is immediately
+typcasted to struct sockaddr_in* type inside the function before use
+
+Upstream-Status: Pending
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ plugins/fault_injection/socket_interposer.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/plugins/fault_injection/socket_interposer.c b/plugins/fault_injection/socket_interposer.c
+index 53c1ebb..ad7adf8 100644
+--- a/plugins/fault_injection/socket_interposer.c
++++ b/plugins/fault_injection/socket_interposer.c
+@@ -100,10 +100,15 @@ socket_interposer_set_callback (struct sockaddr_in *addrin,
+ }
+ 
+ int
+-connect (int socket, const struct sockaddr_in *addrin, socklen_t address_len)
++#if defined(__linux__) && !defined(__GLIBC__)
++connect (int socket, const struct sockaddr *addr, socklen_t address_len)
++#else
++connect (int socket, const struct sockaddr_in *addr, socklen_t address_len)
++#endif
+ {
+   size_t i;
+   int override_errno = 0;
++  struct sockaddr_in* addrin = (struct sockaddr_in*)addr;
+   typedef ssize_t (*real_connect_fn) (int, const struct sockaddr_in *,
+       socklen_t);
+   static real_connect_fn real_connect = 0;

--- a/recipes-multimedia/gstreamer-base/files/0001-gst-gstpluginloader.c-when-env-var-is-set-do-not-fal.patch
+++ b/recipes-multimedia/gstreamer-base/files/0001-gst-gstpluginloader.c-when-env-var-is-set-do-not-fal.patch
@@ -1,0 +1,35 @@
+From a1d7c582392c8bc87fa9411af77b20e011944357 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Thu, 25 Jan 2018 17:55:02 +0200
+Subject: [PATCH] gst/gstpluginloader.c: when env var is set do not fall
+ through to system plugin scanner
+
+If we set a custom GST_PLUGIN_SCANNER env var, then we probably want to use that and only that.
+
+Falling through to the one installed on the system is problamatic in cross-compilation
+environemnts, regardless of whether one pointed to by the env var succeeded or failed.
+
+Upstream-Status: Pending
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ gst/gstpluginloader.c | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/gst/gstpluginloader.c b/gst/gstpluginloader.c
+index 430829d..3a75731 100644
+--- a/gst/gstpluginloader.c
++++ b/gst/gstpluginloader.c
+@@ -471,9 +471,7 @@ gst_plugin_loader_spawn (GstPluginLoader * loader)
+     helper_bin = g_strdup (env);
+     res = gst_plugin_loader_try_helper (loader, helper_bin);
+     g_free (helper_bin);
+-  }
+-
+-  if (!res) {
++  } else {
+     GST_LOG ("Trying installed plugin scanner");
+ 
+ #ifdef G_OS_WIN32
+-- 
+2.15.1
+

--- a/recipes-multimedia/gstreamer-base/files/0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch
+++ b/recipes-multimedia/gstreamer-base/files/0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch
@@ -1,0 +1,40 @@
+From 2b0436f9a07773fae8c74df902d7024e8bfc3512 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Tue, 24 Nov 2015 16:46:27 +0200
+Subject: [PATCH] introspection.m4: prefix pkgconfig paths with
+ PKG_CONFIG_SYSROOT_DIR
+
+We can't use our tweaked introspection.m4 from gobject-introspection tarball
+because gstreamer also defines INTROSPECTION_INIT in its introspection.m4, which
+is later supplied to g-ir-scanner.
+
+Upstream-Status: Pending [review on oe-core list]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+
+---
+ common/m4/introspection.m4 | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/common/m4/introspection.m4 b/common/m4/introspection.m4
+index 162be57..933f979 100644
+--- a/common/m4/introspection.m4
++++ b/common/m4/introspection.m4
+@@ -54,14 +54,14 @@ m4_define([_GOBJECT_INTROSPECTION_CHECK_INTERNAL],
+     INTROSPECTION_GIRDIR=
+     INTROSPECTION_TYPELIBDIR=
+     if test "x$found_introspection" = "xyes"; then
+-       INTROSPECTION_SCANNER=`$PKG_CONFIG --variable=g_ir_scanner gobject-introspection-1.0`
+-       INTROSPECTION_COMPILER=`$PKG_CONFIG --variable=g_ir_compiler gobject-introspection-1.0`
+-       INTROSPECTION_GENERATE=`$PKG_CONFIG --variable=g_ir_generate gobject-introspection-1.0`
++       INTROSPECTION_SCANNER=$PKG_CONFIG_SYSROOT_DIR`$PKG_CONFIG --variable=g_ir_scanner gobject-introspection-1.0`
++       INTROSPECTION_COMPILER=$PKG_CONFIG_SYSROOT_DIR`$PKG_CONFIG --variable=g_ir_compiler gobject-introspection-1.0`
++       INTROSPECTION_GENERATE=$PKG_CONFIG_SYSROOT_DIR`$PKG_CONFIG --variable=g_ir_generate gobject-introspection-1.0`
+        INTROSPECTION_GIRDIR=`$PKG_CONFIG --variable=girdir gobject-introspection-1.0`
+        INTROSPECTION_TYPELIBDIR="$($PKG_CONFIG --variable=typelibdir gobject-introspection-1.0)"
+        INTROSPECTION_CFLAGS=`$PKG_CONFIG --cflags gobject-introspection-1.0`
+        INTROSPECTION_LIBS=`$PKG_CONFIG --libs gobject-introspection-1.0`
+-       INTROSPECTION_MAKEFILE=`$PKG_CONFIG --variable=datadir gobject-introspection-1.0`/gobject-introspection-1.0/Makefile.introspection
++       INTROSPECTION_MAKEFILE=$PKG_CONFIG_SYSROOT_DIR`$PKG_CONFIG --variable=datadir gobject-introspection-1.0`/gobject-introspection-1.0/Makefile.introspection
+        INTROSPECTION_INIT="extern void gst_init(gint*,gchar**); gst_init(NULL,NULL);"
+     fi
+     AC_SUBST(INTROSPECTION_SCANNER)

--- a/recipes-multimedia/gstreamer-base/files/0002-gstconfig.h.in-initial-RISC-V-support.patch
+++ b/recipes-multimedia/gstreamer-base/files/0002-gstconfig.h.in-initial-RISC-V-support.patch
@@ -1,0 +1,30 @@
+From 8a156d1725ecd03f2e8cdc8874e081dda2d3b43d Mon Sep 17 00:00:00 2001
+From: Aurelien Jarno <aurelien@aurel32.net>
+Date: Sun, 15 Apr 2018 00:49:55 +0200
+Subject: [PATCH] gstconfig.h.in: initial RISC-V support
+
+RISC-V supports unaligned accesses, but these might run extremely slowly
+depending on the implementation. Therefore set GST_HAVE_UNALIGNED_ACCESS
+to 0 on this architecture.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=795271
+
+Signed-off-by: Alistair Francis <alistair.francis@wdc.com>
+Upstream-Status: Accepted [1.15.1 - https://bugzilla.gnome.org/show_bug.cgi?id=795271]
+---
+ gst/gstconfig.h.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gst/gstconfig.h.in b/gst/gstconfig.h.in
+index 6351c04da..33dfed1f6 100644
+--- a/gst/gstconfig.h.in
++++ b/gst/gstconfig.h.in
+@@ -104,7 +104,7 @@
+  * http://docs.oracle.com/cd/E19205-01/820-4155/c++_faq.html#Vers6
+  * https://software.intel.com/en-us/node/583402
+  */
+-#if defined(__alpha__) || defined(__arc__) || defined(__arm__) || defined(__aarch64__) || defined(__bfin) || defined(__hppa__) || defined(__nios2__) || defined(__MICROBLAZE__) || defined(__mips__) || defined(__or1k__) || defined(__sh__) || defined(__SH4__) || defined(__sparc__) || defined(__sparc) || defined(__ia64__) || defined(_M_ALPHA) || defined(_M_ARM) || defined(_M_IA64) || defined(__xtensa__) || defined(__e2k__)
++#if defined(__alpha__) || defined(__arc__) || defined(__arm__) || defined(__aarch64__) || defined(__bfin) || defined(__hppa__) || defined(__nios2__) || defined(__MICROBLAZE__) || defined(__mips__) || defined(__or1k__) || defined(__sh__) || defined(__SH4__) || defined(__sparc__) || defined(__sparc) || defined(__ia64__) || defined(_M_ALPHA) || defined(_M_ARM) || defined(_M_IA64) || defined(__xtensa__) || defined(__e2k__) || defined(__riscv)
+ #  define GST_HAVE_UNALIGNED_ACCESS 0
+ #elif defined(__i386__) || defined(__i386) || defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__ppc__) || defined(__ppc64__) || defined(__powerpc__) || defined(__powerpc64__) || defined(__m68k__) || defined(_M_IX86) || defined(_M_AMD64) || defined(_M_X64) || defined(__s390__) || defined(__s390x__) || defined(__zarch__)
+ #  define GST_HAVE_UNALIGNED_ACCESS 1

--- a/recipes-multimedia/gstreamer-base/files/add-a-target-to-compile-tests.patch
+++ b/recipes-multimedia/gstreamer-base/files/add-a-target-to-compile-tests.patch
@@ -1,0 +1,69 @@
+From d61414bc17cf2df019510c2908048c4cabf5cf09 Mon Sep 17 00:00:00 2001
+From: Anuj Mittal <anuj.mittal@intel.com>
+Date: Tue, 27 Feb 2018 09:27:01 +0800
+Subject: [PATCH] add targets for test installation
+
+Targets to make sure tests can be installed and then run on
+the target.
+
+Upstream-Status: Inappropriate [specific to oe setup]
+
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+
+---
+ tests/check/Makefile.am | 27 ++++++++++++++++++++-------
+ 1 file changed, 20 insertions(+), 7 deletions(-)
+
+diff --git a/tests/check/Makefile.am b/tests/check/Makefile.am
+index 13b916d..a66786d 100644
+--- a/tests/check/Makefile.am
++++ b/tests/check/Makefile.am
+@@ -8,11 +8,7 @@ REGISTRY_ENVIRONMENT = \
+ 	GST_REGISTRY=$(CHECK_REGISTRY)
+ 
+ AM_TESTS_ENVIRONMENT += \
+-        GST_STATE_IGNORE_ELEMENTS="$(STATE_IGNORE_ELEMENTS)"	\
+-        $(REGISTRY_ENVIRONMENT)					\
+-        GST_PLUGIN_SCANNER_1_0=$(top_builddir)/libs/gst/helpers/gst-plugin-scanner \
+-        GST_PLUGIN_SYSTEM_PATH_1_0=					\
+-        GST_PLUGIN_PATH_1_0=$(top_builddir)/plugins
++        GST_STATE_IGNORE_ELEMENTS="$(STATE_IGNORE_ELEMENTS)"
+ 
+ plugindir = $(libdir)/gstreamer-@GST_API_VERSION@
+ 
+@@ -178,6 +174,23 @@ noinst_PROGRAMS =
+ 
+ TESTS = $(check_PROGRAMS)
+ 
++install-ptest: $(TESTS)
++	@$(INSTALL) -d $(DESTDIR)
++	@for dir in `find -maxdepth 1 -type d`; do \
++		if [ -x $$dir/.libs ]; then \
++			$(INSTALL) -d $(DESTDIR)/$$dir; \
++			$(INSTALL_PROGRAM) $$dir/.libs/* $(DESTDIR)/$$dir/; \
++		fi \
++	done
++
++runtests:
++	@for b in $(TESTS); do \
++		if [ -x $$b ]; then \
++			$(AM_TESTS_ENVIRONMENT) $(SHELL) test-driver --test-name "$$b" \
++			--log-file $$b.log --trs-file $$b.trs $$b; \
++		fi \
++	done
++
+ noinst_HEADERS = \
+ 	gst/capslist.h \
+ 	gst/struct_arm.h \
+@@ -221,9 +234,9 @@ gst_gstprintf_LDADD = \
+ 	$(LDADD)
+ 
+ elements_fdsrc_CFLAGS=$(GST_OBJ_CFLAGS) $(AM_CFLAGS) \
+-	-DTESTFILE=\"$(top_srcdir)/configure.ac\"
++	-DTESTFILE=\"Makefile\"
+ elements_filesrc_CFLAGS=$(GST_OBJ_CFLAGS) $(AM_CFLAGS) \
+-	-DTESTFILE=\"$(top_srcdir)/configure.ac\"
++	-DTESTFILE=\"Makefile\"
+ 
+ libs_controller_LDADD = \
+ 	$(top_builddir)/libs/gst/controller/libgstcontroller-@GST_API_VERSION@.la \

--- a/recipes-multimedia/gstreamer-base/files/gtk-doc-tweaks.patch
+++ b/recipes-multimedia/gstreamer-base/files/gtk-doc-tweaks.patch
@@ -1,0 +1,47 @@
+From 7018ca1c4bf26c8317e7fcd2e7e4e648195f42ca Mon Sep 17 00:00:00 2001
+From: Ross Burton <ross.burton@intel.com>
+Date: Wed, 20 Dec 2017 13:03:03 +0000
+Subject: [PATCH] gstreamer: use a patch instead of sed to fix gtk-doc
+
+Patch the gtk-doc makefiles so that the qemu wrapper is used to run transient
+binaries instead of libtool wrapper or running them directly.
+
+Also substitute a bogus plugin scanner, as trying to run the real one is causing
+issues during build on x86_64.
+
+Upstream-Status: Inappropriate
+Signed-off-by: Ross Burton <ross.burton@intel.com>
+
+---
+ common/gtk-doc.mak | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/common/gtk-doc.mak b/common/gtk-doc.mak
+index 3f83491..e5cb0d1 100644
+--- a/common/gtk-doc.mak
++++ b/common/gtk-doc.mak
+@@ -6,11 +6,11 @@
+ if GTK_DOC_USE_LIBTOOL
+ GTKDOC_CC = $(LIBTOOL) --tag=CC --mode=compile $(CC) $(INCLUDES) $(GTKDOC_DEPS_CFLAGS) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
+ GTKDOC_LD = $(LIBTOOL) --tag=CC --mode=link $(CC) $(GTKDOC_DEPS_LIBS) $(AM_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS)
+-GTKDOC_RUN = $(LIBTOOL) --mode=execute
++GTKDOC_RUN = $(top_builddir)/gtkdoc-qemuwrapper
+ else
+ GTKDOC_CC = $(CC) $(INCLUDES) $(GTKDOC_DEPS_CFLAGS) $(AM_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
+ GTKDOC_LD = $(CC) $(GTKDOC_DEPS_LIBS) $(AM_CFLAGS) $(CFLAGS) $(AM_LDFLAGS) $(LDFLAGS)
+-GTKDOC_RUN =
++GTKDOC_RUN = $(top_builddir)/gtkdoc-qemuwrapper
+ endif
+ 
+ # We set GPATH here; this gives us semantics for GNU make
+@@ -101,6 +101,7 @@ scan-build.stamp: $(HFILE_GLOB) $(CFILE_GLOB)
+ 	    GST_PLUGIN_PATH_1_0=					\
+ 	    GST_REGISTRY_1_0=doc-registry.xml				\
+ 	    $(GTKDOC_EXTRA_ENVIRONMENT)					\
++	    GST_PLUGIN_SCANNER_1_0="$(top_builddir)/libs/gst/helpers/gst-plugin-scanner-dummy" \
+ 	    CC="$(GTKDOC_CC)" LD="$(GTKDOC_LD)" RUN="$(GTKDOC_RUN)"	\
+ 	    CFLAGS="$(GTKDOC_CFLAGS) $(CFLAGS)"				\
+ 	    LDFLAGS="$(GTKDOC_LIBS) $(LDFLAGS)"				\
+-- 
+2.15.1
+

--- a/recipes-multimedia/gstreamer-base/files/run-ptest
+++ b/recipes-multimedia/gstreamer-base/files/run-ptest
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+make -k runtests

--- a/recipes-multimedia/gstreamer-base/gst-examples/0001-Make-player-examples-installable.patch
+++ b/recipes-multimedia/gstreamer-base/gst-examples/0001-Make-player-examples-installable.patch
@@ -1,0 +1,39 @@
+From 755f6dab07565aca7b6aefacad8be65de364ff75 Mon Sep 17 00:00:00 2001
+From: Jussi Kukkonen <jussi.kukkonen@intel.com>
+Date: Thu, 17 Aug 2017 11:07:02 +0300
+Subject: [PATCH] Make player examples installable
+
+Signed-off-by: Jussi Kukkonen <jussi.kukkonen@intel.com>
+Upstream-Status: Denied [Upstream considers these code examples, for now a least]
+
+https://bugzilla.gnome.org/show_bug.cgi?id=777827
+---
+ playback/player/gst-play/meson.build | 1 +
+ playback/player/gtk/meson.build      | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/playback/player/gst-play/meson.build b/playback/player/gst-play/meson.build
+index 719b55b..a56fe13 100644
+--- a/playback/player/gst-play/meson.build
++++ b/playback/player/gst-play/meson.build
+@@ -8,5 +8,6 @@ executable('gst-play',
+     ['gst-play.c',
+      'gst-play-kb.c',
+      'gst-play-kb.h'],
++    install: true,
+     dependencies : [gst_dep, gstplayer_dep, m_dep])
+ 
+diff --git a/playback/player/gtk/meson.build b/playback/player/gtk/meson.build
+index 08aae4f..671a65d 100644
+--- a/playback/player/gtk/meson.build
++++ b/playback/player/gtk/meson.build
+@@ -18,5 +18,6 @@ executable('gtk-play',
+       gtk_play_resources,
+      'gtk-video-renderer.h',
+      'gtk-video-renderer.c'],
++    install: true,
+     dependencies : [glib_dep, gobject_dep, gmodule_dep, gst_dep, gsttag_dep, gstplayer_dep, gtk_dep, x11_dep])
+ 
+-- 
+2.13.3
+

--- a/recipes-multimedia/gstreamer-base/gst-examples/gst-player.desktop
+++ b/recipes-multimedia/gstreamer-base/gst-examples/gst-player.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Media Player
+Comment=Basic media player
+Icon=multimedia-player
+TryExec=gtk-play
+Exec=gtk-play
+StartupNotify=true
+Terminal=false
+Type=Application
+Categories=GTK;AudioVideo;

--- a/recipes-multimedia/gstreamer-base/gst-examples_git.bb
+++ b/recipes-multimedia/gstreamer-base/gst-examples_git.bb
@@ -1,0 +1,32 @@
+SUMMARY = "GStreamer examples (including gtk-play, gst-play)"
+LICENSE = "LGPL-2.0+"
+LIC_FILES_CHKSUM = "file://playback/player/gtk/gtk-play.c;beginline=1;endline=20;md5=f8c72dae3d36823ec716a9ebcae593b9"
+
+DEPENDS = "glib-2.0 gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad gtk+3 glib-2.0-native"
+
+SRC_URI = "git://gitlab.freedesktop.org/gstreamer/gst-examples.git;protocol=https \
+           file://0001-Make-player-examples-installable.patch \
+           file://gst-player.desktop"
+
+SRCREV = "2b3fc175c252cd5a537e4b2864b572a8372473d6"
+PV = "0.0.1+git${SRCPV}"
+UPSTREAM_CHECK_COMMITS = "1"
+
+S = "${WORKDIR}/git"
+
+inherit meson pkgconfig distro_features_check
+
+
+ANY_OF_DISTRO_FEATURES = "${GTK3DISTROFEATURES}"
+
+do_install_append() {
+	install -m 0644 -D ${WORKDIR}/gst-player.desktop ${D}${datadir}/applications/gst-player.desktop
+}
+
+RDEPENDS_${PN} = "gstreamer1.0-plugins-base-playback"
+RRECOMMENDS_${PN} = "gstreamer1.0-plugins-base-meta \
+                     gstreamer1.0-plugins-good-meta \
+                     gstreamer1.0-plugins-bad-meta \
+                      ${@bb.utils.contains("LICENSE_FLAGS_WHITELIST", "commercial", "gstreamer1.0-libav", "", d)} \
+                     ${@bb.utils.contains("LICENSE_FLAGS_WHITELIST", "commercial", "gstreamer1.0-plugins-ugly-meta", "", d)}"
+RPROVIDES_${PN} += "gst-player gst-player-bin"

--- a/recipes-multimedia/gstreamer-base/gst-plugins-package.inc
+++ b/recipes-multimedia/gstreamer-base/gst-plugins-package.inc
@@ -1,0 +1,56 @@
+PACKAGESPLITFUNCS_prepend = " split_gstreamer10_packages "
+PACKAGESPLITFUNCS_append = " set_metapkg_rdepends "
+
+python split_gstreamer10_packages () {
+    gst_libdir = d.expand('${libdir}/gstreamer-${LIBV}')
+    postinst = d.getVar('plugin_postinst')
+    glibdir = d.getVar('libdir')
+
+    do_split_packages(d, glibdir, r'^lib(.*)\.so\.*', 'lib%s', 'gstreamer %s library', extra_depends='', allow_links=True)
+    do_split_packages(d, gst_libdir, r'libgst(.*)\.so$', d.expand('${PN}-%s'), 'GStreamer plugin for %s', postinst=postinst, extra_depends='')
+    do_split_packages(d, glibdir+'/girepository-1.0', r'Gst(.*)-1.0\.typelib$', d.expand('${PN}-%s-typelib'), 'GStreamer typelib file for %s', postinst=postinst, extra_depends='')
+    do_split_packages(d, gst_libdir, r'libgst(.*)\.la$', d.expand('${PN}-%s-dev'), 'GStreamer plugin for %s (development files)', extra_depends='${PN}-dev')
+    do_split_packages(d, gst_libdir, r'libgst(.*)\.a$', d.expand('${PN}-%s-staticdev'), 'GStreamer plugin for %s (static development files)', extra_depends='${PN}-staticdev')
+}
+
+python set_metapkg_rdepends () {
+    import os
+    import oe.utils
+
+    pn = d.getVar('PN')
+    metapkg =  pn + '-meta'
+    d.setVar('ALLOW_EMPTY_' + metapkg, "1")
+    d.setVar('FILES_' + metapkg, "")
+    blacklist = [ pn, pn + '-meta' ]
+    metapkg_rdepends = []
+    pkgdest = d.getVar('PKGDEST')
+    for pkg in oe.utils.packages_filter_out_system(d):
+        if pkg not in blacklist and pkg not in metapkg_rdepends:
+            # See if the package is empty by looking at the contents of its PKGDEST subdirectory. 
+            # If this subdirectory is empty, then the package is.
+            # Empty packages do not get added to the meta package's RDEPENDS
+            pkgdir = os.path.join(pkgdest, pkg)
+            if os.path.exists(pkgdir):
+                dir_contents = os.listdir(pkgdir) or []
+            else:
+                dir_contents = []
+            is_empty = len(dir_contents) == 0
+            if not is_empty:
+                metapkg_rdepends.append(pkg)
+    d.setVar('RDEPENDS_' + metapkg, ' '.join(metapkg_rdepends))
+    d.setVar('DESCRIPTION_' + metapkg, pn + ' meta package')
+}
+
+# each plugin-dev depends on PN-dev, plugin-staticdev on PN-staticdev
+# so we need them even when empty (like in gst-plugins-good case)
+ALLOW_EMPTY_${PN} = "1"
+ALLOW_EMPTY_${PN}-dev = "1"
+ALLOW_EMPTY_${PN}-staticdev = "1"
+
+PACKAGES += "${PN}-apps ${PN}-meta ${PN}-glib"
+
+FILES_${PN} = ""
+FILES_${PN}-apps = "${bindir}"
+FILES_${PN}-glib = "${datadir}/glib-2.0"
+
+RRECOMMENDS_${PN} += "${PN}-meta"

--- a/recipes-multimedia/gstreamer-base/gst-validate_1.14.4.bb
+++ b/recipes-multimedia/gstreamer-base/gst-validate_1.14.4.bb
@@ -1,0 +1,25 @@
+SUMMARY = "Gstreamer validation tool"
+DESCRIPTION = "A Tool to test GStreamer components"
+HOMEPAGE = "https://gstreamer.freedesktop.org/releases/gst-validate/1.12.3.html"
+SECTION = "multimedia"
+
+LICENSE = "LGPLv2.1"
+LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343"
+
+SRC_URI = "https://gstreamer.freedesktop.org/src/${BPN}/${BP}.tar.xz \
+           file://0001-connect-has-a-different-signature-on-musl.patch \
+           "
+SRC_URI[md5sum] = "1f4fc5308695adfdc11d13046aa4888c"
+SRC_URI[sha256sum] = "18dccca94bdc0bab3cddb07817bd280df7ab4abbec9a83b92620367a22d955c7"
+
+DEPENDS = "json-glib glib-2.0 glib-2.0-native gstreamer1.0 gstreamer1.0-plugins-base"
+RRECOMMENDS_${PN} = "git"
+
+FILES_${PN} += "${datadir}/gstreamer-1.0/* ${libdir}/gst-validate-launcher/* ${libdir}/gstreamer-1.0/*"
+
+inherit pkgconfig gettext autotools gobject-introspection gtk-doc upstream-version-is-even
+
+# With gtk-doc enabled this recipe fails to build, so forcibly disable it:
+# WORKDIR/build/docs/validate/gst-validate-scan: line 117:
+# WORKDIR/build/docs/validate/.libs/lt-gst-validate-scan: No such file or directory
+GTKDOC_ENABLED = "False"

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-libav/0001-Disable-yasm-for-libav-when-disable-yasm.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-libav/0001-Disable-yasm-for-libav-when-disable-yasm.patch
@@ -1,0 +1,33 @@
+From 54bba228ea52d01fd84941d97be23c03f9862b64 Mon Sep 17 00:00:00 2001
+From: Carlos Rafael Giani <dv@pseudoterminal.org>
+Date: Sat, 6 Apr 2013 01:22:22 +0200
+Subject: [PATCH] Disable yasm for libav when --disable-yasm
+
+Upstream-Status: Inappropriate [configuration]
+
+Signed-off-by: Shane Wang <shane.wang@intel.com>
+Signed-off-by: Carlos Rafael Giani <dv@pseudoterminal.org>
+---
+ configure.ac | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index 22ede88..ef3c050 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -305,6 +305,12 @@ else
+     emblibav_configure_args="$emblibav_configure_args --enable-gpl"
+   fi
+
++  AC_ARG_ENABLE(yasm,
++              [AC_HELP_STRING([--disable-yasm], [disable use of yasm assembler])])
++  if test "x$enable_yasm" = "xno"; then
++    emblibav_configure_args="$emblibav_configure_args --disable-yasm"
++  fi
++
+   # if we are cross-compiling, tell libav so
+   case $host in
+       *android*)
+-- 
+1.8.2
+

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-libav/0001-configure-check-for-armv7ve-variant.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-libav/0001-configure-check-for-armv7ve-variant.patch
@@ -1,0 +1,35 @@
+From aac5902d3c9cb35c771e760d0e487622aa2e116a Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Thu, 20 Apr 2017 10:38:18 -0700
+Subject: [PATCH] configure: check for armv7ve variant
+
+OE passes -mcpu and -march via cmdline and if
+package tries to detect one of it own then it
+should be compatible otherwise, newer gcc7+ will
+error out
+
+Check for relevant preprocessor macro to determine
+armv7ve architecture
+
+Upstream-Status: Pending
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ gst-libs/ext/libav/configure | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/gst-libs/ext/libav/configure b/gst-libs/ext/libav/configure
+index 4a5e477..727818e 100755
+--- a/gst-libs/ext/libav/configure
++++ b/gst-libs/ext/libav/configure
+@@ -4295,6 +4295,7 @@ elif enabled arm; then
+         elif check_arm_arch 6Z;       then echo armv6z
+         elif check_arm_arch 6ZK;      then echo armv6zk
+         elif check_arm_arch 6T2;      then echo armv6t2
++        elif check_arm_arch EXT_IDIV; then echo armv7ve
+         elif check_arm_arch 7;        then echo armv7
+         elif check_arm_arch 7A  7_A;  then echo armv7-a
+         elif check_arm_arch 7S;       then echo armv7-a
+-- 
+2.12.2
+

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-libav/0001-fix-host-contamination.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-libav/0001-fix-host-contamination.patch
@@ -1,0 +1,36 @@
+From c1700f867f876ee33c130a8e28b688e2b1d89663 Mon Sep 17 00:00:00 2001
+From: Anuj Mittal <anuj.mittal@intel.com>
+Date: Wed, 11 Apr 2018 17:14:55 +0800
+Subject: [PATCH] Prevent host contamination
+
+Remove reference to host $(libdir) from .la files.
+
+Upstream-Status: Inappropriate [cross-compile specific]
+
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+---
+ gst-libs/ext/Makefile.am | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gst-libs/ext/Makefile.am b/gst-libs/ext/Makefile.am
+index 6cdc048..a19d255 100644
+--- a/gst-libs/ext/Makefile.am
++++ b/gst-libs/ext/Makefile.am
+@@ -49,7 +49,7 @@ echo "  GEN      $1.la" && \
+  echo "library_names=''" && \
+  echo "old_library='$1.a'" && \
+  echo "inherited_linker_flags=''" && \
+- echo "dependency_libs=' -L$(libdir) $(if $2,$(foreach dep,$2,$(abs_builddir)/$(dep).la)) $(call find_library_la,$3 $(LIBM),$(LDFLAGS)) '" && \
++ echo "dependency_libs=' -L $(if $2,$(foreach dep,$2,$(abs_builddir)/$(dep).la)) $(call find_library_la,$3 $(LIBM),$(LDFLAGS)) '" && \
+  echo "weak_library_names=''" &&  \
+  echo "current=" && \
+  echo "age=" && \
+@@ -58,7 +58,7 @@ echo "  GEN      $1.la" && \
+  echo "shouldnotlink=no" && \
+  echo "dlopen=''" && \
+  echo "dlpreopen=''" && \
+- echo "libdir='$(libdir)'") > $1.la
++ echo "libdir=''") > $1.la
+ endef
+ 
+ libavutil.la:

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-libav/mips64_cpu_detection.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-libav/mips64_cpu_detection.patch
@@ -1,0 +1,32 @@
+It will add -mips64r6 and -mips64r2 to cmdline which will
+cause conflicts
+
+in OE we user mips32r2 and mips64r2 for mips arch versions
+so there is no benefit of detecting it automatically by
+poking at tools especially in cross env
+
+Fixes errors like
+
+linking -mnan=2008 module with previous -mnan=legacy modules
+failed to merge target specific data of file
+
+-Khem
+Upstream-Status: Inappropriate [OE-Specific]
+
+Index: gst-libav-1.10.1/gst-libs/ext/libav/configure
+===================================================================
+--- gst-libav-1.10.1.orig/gst-libs/ext/libav/configure
++++ gst-libav-1.10.1/gst-libs/ext/libav/configure
+@@ -5269,12 +5269,9 @@ elif enabled mips; then
+ 
+     # Enable minimum ISA based on selected options
+     if enabled mips64; then
+-        enabled mips64r6 && check_inline_asm_flags mips64r6 '"dlsa $0, $0, $0, 1"' '-mips64r6'
+         enabled mips64r2 && check_inline_asm_flags mips64r2 '"dext $0, $0, 0, 1"' '-mips64r2'
+         disabled mips64r6 && disabled mips64r2 && check_inline_asm_flags mips64r1 '"daddi $0, $0, 0"' '-mips64'
+     else
+-        enabled mips32r6 && check_inline_asm_flags mips32r6 '"aui $0, $0, 0"' '-mips32r6'
+-        enabled mips32r5 && check_inline_asm_flags mips32r5 '"eretnc"' '-mips32r5'
+         enabled mips32r2 && check_inline_asm_flags mips32r2 '"ext $0, $0, 0, 1"' '-mips32r2'
+         disabled mips32r6 && disabled mips32r5 && disabled mips32r2 && check_inline_asm_flags mips32r1 '"addi $0, $0, 0"' '-mips32'
+     fi

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-libav/workaround-to-build-gst-libav-for-i586-with-gcc.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-libav/workaround-to-build-gst-libav-for-i586-with-gcc.patch
@@ -1,0 +1,26 @@
+Description: Workaround to build libav for i586 with gcc 4.9.2 by avoiding memset
+Author: Bernhard Übelacker <bernhardu@vr-web.de>
+
+---
+Bug-Debian: https://bugs.debian.org/783082
+Last-Update: 2015-04-28
+
+Upstream-Status: Backport [debian]
+
+Signed-off-by: Robert Yang <liezhi.yang@windriver.com>
+
+--- gst-libav-1.4.5.orig/gst-libs/ext/libav/libavcodec/h264_cabac.c
++++ gst-libav-1.4.5/gst-libs/ext/libav/libavcodec/h264_cabac.c
+@@ -2020,7 +2020,11 @@ decode_intra_mb:
+         // In deblocking, the quantizer is 0
+         h->cur_pic.qscale_table[mb_xy] = 0;
+         // All coeffs are present
+-        memset(h->non_zero_count[mb_xy], 16, 48);
++        /*memset(h->non_zero_count[mb_xy], 16, 48);*/
++            /* avoiding this memset because it leads at least with gcc4.9.2 to error: 'asm' operand has impossible constraints */
++        for (size_t i = 0; i < 48; i++) {
++            ( (unsigned char*)(h->non_zero_count[mb_xy]) ) [i] = 16;
++        }
+         h->cur_pic.mb_type[mb_xy] = mb_type;
+         sl->last_qscale_diff = 0;
+         return 0;

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-libav_1.14.4.bb
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-libav_1.14.4.bb
@@ -1,0 +1,70 @@
+SUMMARY = "Libav-based GStreamer 1.x plugin"
+HOMEPAGE = "http://gstreamer.freedesktop.org/"
+SECTION = "multimedia"
+
+LICENSE = "GPLv2+ & LGPLv2+ & ( (GPLv2+ & LGPLv2.1+) | (GPLv3+ & LGPLv3+) )"
+LICENSE_FLAGS = "commercial"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+                    file://COPYING.LIB;md5=6762ed442b3822387a51c92d928ead0d \
+                    file://ext/libav/gstav.h;beginline=1;endline=18;md5=a752c35267d8276fd9ca3db6994fca9c \
+                    file://gst-libs/ext/libav/COPYING.GPLv2;md5=b234ee4d69f5fce4486a80fdaf4a4263 \
+                    file://gst-libs/ext/libav/COPYING.GPLv3;md5=d32239bcb673463ab874e80d47fae504 \
+                    file://gst-libs/ext/libav/COPYING.LGPLv2.1;md5=bd7a443320af8c812e4c18d1b79df004 \
+                    file://gst-libs/ext/libav/COPYING.LGPLv3;md5=e6a600fd5e1d9cbde2d983680233ad02"
+
+SRC_URI = "http://gstreamer.freedesktop.org/src/gst-libav/gst-libav-${PV}.tar.xz \
+           file://0001-Disable-yasm-for-libav-when-disable-yasm.patch \
+           file://workaround-to-build-gst-libav-for-i586-with-gcc.patch \
+           file://mips64_cpu_detection.patch \
+           file://0001-configure-check-for-armv7ve-variant.patch \
+           file://0001-fix-host-contamination.patch \
+           "
+SRC_URI[md5sum] = "58342db11dbb201a66a62577dcf7bab5"
+SRC_URI[sha256sum] = "dfd78591901df7853eab7e56a86c34a1b03635da0d3d56b89aa577f1897865da"
+
+S = "${WORKDIR}/gst-libav-${PV}"
+
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base zlib bzip2 xz"
+
+inherit autotools pkgconfig upstream-version-is-even gtk-doc
+
+# CAUTION: Using the system libav is not recommended. Since the libav API is changing all the time,
+# compilation errors (and other, more subtle bugs) can happen. It is usually better to rely on the
+# libav copy included in the gst-libav package.
+PACKAGECONFIG ??= "orc yasm"
+
+PACKAGECONFIG[gpl] = "--enable-gpl,--disable-gpl,"
+PACKAGECONFIG[libav] = "--with-system-libav,,libav"
+PACKAGECONFIG[orc] = "--enable-orc,--disable-orc,orc"
+PACKAGECONFIG[yasm] = "--enable-yasm,--disable-yasm,nasm-native"
+PACKAGECONFIG[valgrind] = "--enable-valgrind,--disable-valgrind,valgrind"
+
+GSTREAMER_1_0_DEBUG ?= "--disable-debug"
+
+LIBAV_EXTRA_CONFIGURE = "--with-libav-extra-configure"
+
+LIBAV_EXTRA_CONFIGURE_COMMON_ARG = "--target-os=linux \
+  --cc='${CC}' --as='${CC}' --ld='${CC}' --nm='${NM}' --ar='${AR}' \
+  --ranlib='${RANLIB}' \
+  ${GSTREAMER_1_0_DEBUG} \
+  --cross-prefix='${HOST_PREFIX}'"
+
+# Disable assembly optimizations for X32, as this libav lacks the support
+PACKAGECONFIG_remove_linux-gnux32 = "yasm"
+LIBAV_EXTRA_CONFIGURE_COMMON_ARG_append_linux-gnux32 = " --disable-asm"
+
+LIBAV_EXTRA_CONFIGURE_COMMON = \
+'${LIBAV_EXTRA_CONFIGURE}="${LIBAV_EXTRA_CONFIGURE_COMMON_ARG}"'
+
+EXTRA_OECONF = "${LIBAV_EXTRA_CONFIGURE_COMMON}"
+
+FILES_${PN} += "${libdir}/gstreamer-1.0/*.so"
+FILES_${PN}-dev += "${libdir}/gstreamer-1.0/*.la"
+FILES_${PN}-staticdev += "${libdir}/gstreamer-1.0/*.a"
+
+# http://errors.yoctoproject.org/Errors/Details/20493/
+ARM_INSTRUCTION_SET_armv4 = "arm"
+ARM_INSTRUCTION_SET_armv5 = "arm"
+
+# ffmpeg/libav disables PIC on some platforms (e.g. x86-32)
+INSANE_SKIP_${PN} = "textrel"

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-meta-base.bb
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-meta-base.bb
@@ -1,0 +1,68 @@
+SUMMARY = "Gstreamer1.0 package groups"
+LICENSE = "MIT"
+
+# Due to use of COMBINED_FEATURES
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+inherit packagegroup
+
+COMMERCIAL_PLUGINS = "${COMMERCIAL_AUDIO_PLUGINS} ${COMMERCIAL_VIDEO_PLUGINS}"
+DEPENDS_UGLY="${@'gstreamer1.0-plugins-ugly' if 'ugly' in COMMERCIAL_PLUGINS.split('-') else ''}"
+DEPENDS_BAD="${@'gstreamer1.0-plugins-bad' if 'bad' in COMMERCIAL_PLUGINS.split('-') else ''}"
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good ${DEPENDS_UGLY} ${DEPENDS_BAD}"
+
+PACKAGES = "\
+    gstreamer1.0-meta-base \
+    gstreamer1.0-meta-x11-base \
+    gstreamer1.0-meta-audio \
+    gstreamer1.0-meta-debug \
+    gstreamer1.0-meta-video"
+
+ALLOW_EMPTY_gstreamer1.0-meta-base = "1"
+ALLOW_EMPTY_gstreamer1.0-meta-x11-base = "1"
+ALLOW_EMPTY_gstreamer1.0-meta-audio = "1"
+ALLOW_EMPTY_gstreamer1.0-meta-debug = "1"
+ALLOW_EMPTY_gstreamer1.0-meta-video = "1"
+
+RDEPENDS_gstreamer1.0-meta-base = "\
+    ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'gstreamer1.0-meta-x11-base', '', d)} \
+    gstreamer1.0 \
+    gstreamer1.0-plugins-base-playback \
+    gstreamer1.0-plugins-base-gio \
+    ${@bb.utils.contains('COMBINED_FEATURES', 'alsa', 'gstreamer1.0-plugins-base-alsa', '',d)} \
+    gstreamer1.0-plugins-base-volume \
+    gstreamer1.0-plugins-base-audioconvert \
+    gstreamer1.0-plugins-base-audioresample \
+    gstreamer1.0-plugins-base-typefindfunctions \
+    gstreamer1.0-plugins-base-videoscale \
+    gstreamer1.0-plugins-base-videoconvert \
+    gstreamer1.0-plugins-good-autodetect \
+    gstreamer1.0-plugins-good-soup"
+
+RRECOMMENDS_gstreamer1.0-meta-x11-base = "\
+    gstreamer1.0-plugins-base-ximagesink \
+    gstreamer1.0-plugins-base-xvimagesink"
+
+RDEPENDS_gstreamer1.0-meta-audio = "\
+    gstreamer1.0-meta-base \
+    gstreamer1.0-plugins-base-vorbis \
+    gstreamer1.0-plugins-base-ogg \
+    gstreamer1.0-plugins-good-wavparse \
+    gstreamer1.0-plugins-good-flac \
+    ${COMMERCIAL_AUDIO_PLUGINS}"
+
+RDEPENDS_gstreamer1.0-meta-debug = "\
+    gstreamer1.0-meta-base \
+    gstreamer1.0-plugins-good-debug \
+    gstreamer1.0-plugins-base-audiotestsrc \
+    gstreamer1.0-plugins-base-videotestsrc"
+
+RDEPENDS_gstreamer1.0-meta-video = "\
+    gstreamer1.0-meta-base \
+    gstreamer1.0-plugins-good-avi \
+    gstreamer1.0-plugins-good-matroska \
+    gstreamer1.0-plugins-base-theora \
+    ${COMMERCIAL_VIDEO_PLUGINS}"
+
+RRECOMMENDS_gstreamer1.0-meta-video = "\
+    gstreamer1.0-meta-audio"

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-omx_1.14.4.bb
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-omx_1.14.4.bb
@@ -1,0 +1,57 @@
+SUMMARY = "OpenMAX IL plugins for GStreamer"
+HOMEPAGE = "http://gstreamer.freedesktop.org/"
+SECTION = "multimedia"
+
+LICENSE = "LGPLv2.1"
+LICENSE_FLAGS = "commercial"
+LIC_FILES_CHKSUM = "file://COPYING;md5=4fbd65380cdd255951079008b364516c \
+                    file://omx/gstomx.h;beginline=1;endline=21;md5=5c8e1fca32704488e76d2ba9ddfa935f"
+
+SRC_URI = "http://gstreamer.freedesktop.org/src/gst-omx/gst-omx-${PV}.tar.xz"
+
+SRC_URI[md5sum] = "81e67ea03be607b7c548ce911598d754"
+SRC_URI[sha256sum] = "969870e75c1f75c96f8783530e2c2932fc3afbfd976eb0c466f51dae268ea3d4"
+
+S = "${WORKDIR}/gst-omx-${PV}"
+
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad"
+
+inherit autotools pkgconfig gettext gtk-doc upstream-version-is-even
+
+acpaths = "-I ${S}/common/m4 -I ${S}/m4"
+
+GSTREAMER_1_0_OMX_TARGET ?= "bellagio"
+GSTREAMER_1_0_OMX_CORE_NAME ?= "${libdir}/libomxil-bellagio.so.0"
+
+EXTRA_OECONF += "--disable-valgrind --with-omx-target=${GSTREAMER_1_0_OMX_TARGET}"
+
+python __anonymous () {
+    omx_target = d.getVar("GSTREAMER_1_0_OMX_TARGET")
+    if omx_target in ['generic', 'bellagio']:
+        # Bellagio headers are incomplete (they are missing the OMX_VERSION_MAJOR,#
+        # OMX_VERSION_MINOR, OMX_VERSION_REVISION, and OMX_VERSION_STEP macros);
+        # appending a directory path to gst-omx' internal OpenMAX IL headers fixes this
+        d.appendVar("CFLAGS", " -I${S}/omx/openmax")
+    elif omx_target == "rpi":
+        # Dedicated Raspberry Pi OpenMAX IL support makes this package machine specific
+        d.setVar("PACKAGE_ARCH", d.getVar("MACHINE_ARCH"))
+}
+
+delete_pkg_m4_file() {
+    # Delete m4 files which we provide patched versions of but will be ignored
+    # if these exist
+	rm -f "${S}/common/m4/pkg.m4"
+	rm -f "${S}/common/m4/gtk-doc.m4"
+}
+do_configure[prefuncs] += "delete_pkg_m4_file"
+
+set_omx_core_name() {
+	sed -i -e "s;^core-name=.*;core-name=${GSTREAMER_1_0_OMX_CORE_NAME};" "${D}${sysconfdir}/xdg/gstomx.conf"
+}
+do_install[postfuncs] += " set_omx_core_name "
+
+FILES_${PN} += "${libdir}/gstreamer-1.0/*.so"
+FILES_${PN}-dev += "${libdir}/gstreamer-1.0/*.la"
+FILES_${PN}-staticdev += "${libdir}/gstreamer-1.0/*.a"
+
+RDEPENDS_${PN} = "libomxil"

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-bad/0001-Makefile.am-don-t-hardcode-libtool-name-when-running.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-bad/0001-Makefile.am-don-t-hardcode-libtool-name-when-running.patch
@@ -1,0 +1,43 @@
+From 7d8e8b8bcce34d01fc7ad7285b4eb17ad8949399 Mon Sep 17 00:00:00 2001
+From: Anuj Mittal <anuj.mittal@intel.com>
+Date: Wed, 11 Apr 2018 11:06:39 +0800
+Subject: [PATCH] Makefile.am: don't hardcode libtool name when running 
+ introspection tools
+
+Upstream-Status: Pending [review on oe-core list]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+Signed-off-by: Maxin B. John <maxin.john@intel.com>
+---
+ gst-libs/gst/insertbin/Makefile.am | 2 +-
+ gst-libs/gst/mpegts/Makefile.am    | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/gst-libs/gst/insertbin/Makefile.am b/gst-libs/gst/insertbin/Makefile.am
+index 1f8ea30..4b98ef6 100644
+--- a/gst-libs/gst/insertbin/Makefile.am
++++ b/gst-libs/gst/insertbin/Makefile.am
+@@ -45,7 +45,7 @@ GstInsertBin-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstinsertbin-@GS
+ 		--library=libgstinsertbin-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-insertbin-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/mpegts/Makefile.am b/gst-libs/gst/mpegts/Makefile.am
+index f264e33..9934a4d 100644
+--- a/gst-libs/gst/mpegts/Makefile.am
++++ b/gst-libs/gst/mpegts/Makefile.am
+@@ -82,7 +82,7 @@ GstMpegts-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstmpegts-@GST_API_
+ 		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-video-@GST_API_VERSION@` \
+ 		--library=libgstmpegts-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-video-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-mpegts-@GST_API_VERSION@ \
+-- 
+2.7.4
+

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-bad/avoid-including-sys-poll.h-directly.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-bad/avoid-including-sys-poll.h-directly.patch
@@ -1,0 +1,30 @@
+From 72561a0fca562d03567ace7b4cfc94992cd6525c Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Wed, 3 Feb 2016 18:05:41 -0800
+Subject: [PATCH] avoid including <sys/poll.h> directly
+
+musl libc generates warnings if <sys/poll.h> is included directly.
+
+Upstream-Status: Pending
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+---
+ sys/dvb/gstdvbsrc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sys/dvb/gstdvbsrc.c b/sys/dvb/gstdvbsrc.c
+index b93255f..49f145a 100644
+--- a/sys/dvb/gstdvbsrc.c
++++ b/sys/dvb/gstdvbsrc.c
+@@ -93,7 +93,7 @@
+ #include <gst/gst.h>
+ #include <gst/glib-compat-private.h>
+ #include <sys/ioctl.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <fcntl.h>
+ #include <errno.h>
+ #include <stdio.h>
+-- 
+1.9.1
+

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-bad/configure-allow-to-disable-libssh2.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-bad/configure-allow-to-disable-libssh2.patch
@@ -1,0 +1,61 @@
+From f59c5269f92d59a5296cbfeeb682d42095cd88ad Mon Sep 17 00:00:00 2001
+From: Wenzong Fan <wenzong.fan@windriver.com>
+Date: Thu, 18 Sep 2014 02:24:07 -0400
+Subject: [PATCH] gstreamer1.0-plugins-bad: allow to disable libssh2
+
+libssh2 is automatically linked to if present, this undetermined
+dependency may cause build errors like:
+
+  .../x86_64-poky-linux/4.9.0/ld: cannot find -lssh2
+
+libssh2 isn't an oe-core recipe, so allow to disable it from
+configure.
+
+Upstream-Status: Pending
+
+Signed-off-by: Wenzong Fan <wenzong.fan@windriver.com>
+---
+ configure.ac |   23 +++++++++++++++++------
+ 1 file changed, 17 insertions(+), 6 deletions(-)
+
+Index: gst-plugins-bad-1.12.3/configure.ac
+===================================================================
+--- gst-plugins-bad-1.12.3.orig/configure.ac
++++ gst-plugins-bad-1.12.3/configure.ac
+@@ -2139,6 +2139,15 @@ AG_GST_CHECK_FEATURE(CHROMAPRINT, [chrom
+ ])
+ 
+ dnl *** Curl ***
++AC_ARG_ENABLE([libssh2],
++     [  --enable-libssh2		enable LIBSSH2 support @<:@default=auto@:>@],
++     [case "${enableval}" in
++       yes)  NEED_SSH2=yes ;;
++       no)   NEED_SSH2=no ;;
++       auto) NEED_SSH2=auto ;;
++       *) AC_MSG_ERROR([bad value ${enableval} for --enable-libssh2]) ;;
++     esac],[NEED_SSH2=auto])
++
+ translit(dnm, m, l) AM_CONDITIONAL(USE_CURL, true)
+ AG_GST_CHECK_FEATURE(CURL, [Curl plugin], curl, [
+   PKG_CHECK_MODULES(CURL, libcurl >= 7.35.0, [
+@@ -2161,12 +2170,14 @@ AG_GST_CHECK_FEATURE(CURL, [Curl plugin]
+   ])
+   AC_SUBST(CURL_CFLAGS)
+   AC_SUBST(CURL_LIBS)
+-  PKG_CHECK_MODULES(SSH2, libssh2 >= 1.4.3, [
+-    HAVE_SSH2="yes"
+-    AC_DEFINE(HAVE_SSH2, 1, [Define if libssh2 is available])
+-  ], [
+-    HAVE_SSH2="no"
+-  ])
++  if test "x$NEED_SSH2" != "xno"; then
++    PKG_CHECK_MODULES(SSH2, libssh2 >= 1.4.3, [
++      HAVE_SSH2="yes"
++      AC_DEFINE(HAVE_SSH2, 1, [Define if libssh2 is available])
++    ], [
++      HAVE_SSH2="no"
++    ])
++  fi
+   AM_CONDITIONAL(USE_SSH2, test "x$HAVE_SSH2" = "xyes")
+   AC_SUBST(SSH2_CFLAGS)
+   AC_SUBST(SSH2_LIBS)

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-bad/ensure-valid-sentinels-for-gst_structure_get-etc.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-bad/ensure-valid-sentinels-for-gst_structure_get-etc.patch
@@ -1,0 +1,85 @@
+From 2262ba4b686d5cc0d3e894707fe1d31619a3a8f1 Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Tue, 9 Feb 2016 14:00:00 -0800
+Subject: [PATCH] ensure valid sentinals for gst_structure_get() etc
+
+For GStreamer functions declared with G_GNUC_NULL_TERMINATED,
+ie __attribute__((__sentinel__)), gcc will generate a warning if the
+last parameter passed to the function is not NULL (where a valid NULL
+in this context is defined as zero with any pointer type).
+
+The C callers to such functions within gst-plugins-bad use the C NULL
+definition (ie ((void*)0)), which is a valid sentinel.
+
+However the C++ NULL definition (ie 0L), is not a valid sentinel
+without an explicit cast to a pointer type.
+
+Upstream-Status: Pending
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+---
+ sys/decklink/gstdecklink.cpp          | 10 +++++-----
+ sys/decklink/gstdecklinkaudiosrc.cpp  |  2 +-
+ sys/decklink/gstdecklinkvideosink.cpp |  2 +-
+ 3 files changed, 7 insertions(+), 7 deletions(-)
+
+Index: gst-plugins-bad-1.10.2/sys/decklink/gstdecklink.cpp
+===================================================================
+--- gst-plugins-bad-1.10.2.orig/sys/decklink/gstdecklink.cpp
++++ gst-plugins-bad-1.10.2/sys/decklink/gstdecklink.cpp
+@@ -476,7 +476,7 @@ gst_decklink_mode_get_structure (GstDeck
+       "pixel-aspect-ratio", GST_TYPE_FRACTION, mode->par_n, mode->par_d,
+       "interlace-mode", G_TYPE_STRING,
+       mode->interlaced ? "interleaved" : "progressive",
+-      "framerate", GST_TYPE_FRACTION, mode->fps_n, mode->fps_d, NULL);
++      "framerate", GST_TYPE_FRACTION, mode->fps_n, mode->fps_d, (void*)NULL);
+ 
+   if (input && mode->interlaced) {
+     if (mode->tff)
+@@ -489,16 +489,16 @@ gst_decklink_mode_get_structure (GstDeck
+     case bmdFormat8BitYUV:     /* '2vuy' */
+       gst_structure_set (s, "format", G_TYPE_STRING, "UYVY",
+           "colorimetry", G_TYPE_STRING, mode->colorimetry,
+-          "chroma-site", G_TYPE_STRING, "mpeg2", NULL);
++          "chroma-site", G_TYPE_STRING, "mpeg2", (void*)NULL);
+       break;
+     case bmdFormat10BitYUV:    /* 'v210' */
+-      gst_structure_set (s, "format", G_TYPE_STRING, "v210", NULL);
++      gst_structure_set (s, "format", G_TYPE_STRING, "v210", (void*)NULL);
+       break;
+     case bmdFormat8BitARGB:    /* 'ARGB' */
+-      gst_structure_set (s, "format", G_TYPE_STRING, "ARGB", NULL);
++      gst_structure_set (s, "format", G_TYPE_STRING, "ARGB", (void*)NULL);
+       break;
+     case bmdFormat8BitBGRA:    /* 'BGRA' */
+-      gst_structure_set (s, "format", G_TYPE_STRING, "BGRA", NULL);
++      gst_structure_set (s, "format", G_TYPE_STRING, "BGRA", (void*)NULL);
+       break;
+     case bmdFormat10BitRGB:    /* 'r210' Big-endian RGB 10-bit per component with SMPTE video levels (64-960). Packed as 2:10:10:10 */
+     case bmdFormat12BitRGB:    /* 'R12B' Big-endian RGB 12-bit per component with full range (0-4095). Packed as 12-bit per component */
+Index: gst-plugins-bad-1.10.2/sys/decklink/gstdecklinkaudiosrc.cpp
+===================================================================
+--- gst-plugins-bad-1.10.2.orig/sys/decklink/gstdecklinkaudiosrc.cpp
++++ gst-plugins-bad-1.10.2/sys/decklink/gstdecklinkaudiosrc.cpp
+@@ -322,7 +322,7 @@ gst_decklink_audio_src_set_caps (GstBase
+       g_mutex_unlock (&self->input->lock);
+ 
+       if (videosrc) {
+-        g_object_get (videosrc, "connection", &vconn, NULL);
++        g_object_get (videosrc, "connection", &vconn, (void *) NULL);
+         gst_object_unref (videosrc);
+ 
+         switch (vconn) {
+Index: gst-plugins-bad-1.10.2/sys/decklink/gstdecklinkvideosink.cpp
+===================================================================
+--- gst-plugins-bad-1.10.2.orig/sys/decklink/gstdecklinkvideosink.cpp
++++ gst-plugins-bad-1.10.2/sys/decklink/gstdecklinkvideosink.cpp
+@@ -163,7 +163,7 @@ reset_framerate (GstCapsFeatures * featu
+     gpointer user_data)
+ {
+   gst_structure_set (structure, "framerate", GST_TYPE_FRACTION_RANGE, 0, 1,
+-      G_MAXINT, 1, NULL);
++      G_MAXINT, 1, (void *) NULL);
+ 
+   return TRUE;
+ }

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-bad/fix-maybe-uninitialized-warnings-when-compiling-with-Os.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-bad/fix-maybe-uninitialized-warnings-when-compiling-with-Os.patch
@@ -1,0 +1,28 @@
+From a67781000e82bd9ae3813da29401e8c0c852328a Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Tue, 26 Jan 2016 15:16:01 -0800
+Subject: [PATCH] fix maybe-uninitialized warnings when compiling with -Os
+
+Upstream-Status: Pending
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+---
+ gst-libs/gst/codecparsers/gstvc1parser.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gst-libs/gst/codecparsers/gstvc1parser.c b/gst-libs/gst/codecparsers/gstvc1parser.c
+index fd16ee0..ddb890c 100644
+--- a/gst-libs/gst/codecparsers/gstvc1parser.c
++++ b/gst-libs/gst/codecparsers/gstvc1parser.c
+@@ -1729,7 +1729,7 @@ gst_vc1_parse_sequence_layer (const guint8 * data, gsize size,
+     GstVC1SeqLayer * seqlayer)
+ {
+   guint32 tmp;
+-  guint8 tmp8;
++  guint8 tmp8 = 0;
+   guint8 structA[8] = { 0, };
+   guint8 structB[12] = { 0, };
+   GstBitReader br;
+-- 
+1.9.1
+

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-bad_1.14.4.bb
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-bad_1.14.4.bb
@@ -36,7 +36,7 @@ PACKAGECONFIG ??= " \
 # not add GL dependencies here, since these are taken care of in -base.
 
 PACKAGECONFIG[assrender]       = "--enable-assrender,--disable-assrender,libass"
-PACKAGECONFIG[bluez]           = "--enable-bluez,--disable-bluez,${BLUEZ}"
+PACKAGECONFIG[bluez]           = "--enable-bluez,--disable-bluez,bluez5"
 PACKAGECONFIG[bz2]             = "--enable-bz2,--disable-bz2,bzip2"
 PACKAGECONFIG[curl]            = "--enable-curl,--disable-curl,curl"
 PACKAGECONFIG[dash]            = "--enable-dash,--disable-dash,libxml2"
@@ -77,7 +77,7 @@ PACKAGECONFIG[ttml]            = "--enable-ttml,--disable-ttml,libxml2 pango cai
 PACKAGECONFIG[uvch264]         = "--enable-uvch264,--disable-uvch264,libusb1 libgudev"
 PACKAGECONFIG[voaacenc]        = "--enable-voaacenc,--disable-voaacenc,vo-aacenc"
 PACKAGECONFIG[voamrwbenc]      = "--enable-voamrwbenc,--disable-voamrwbenc,vo-amrwbenc"
-PACKAGECONFIG[vulkan]          = "--enable-vulkan,--disable-vulkan,vulkan"
+PACKAGECONFIG[vulkan]          = "--enable-vulkan,--disable-vulkan,vulkan-loader"
 PACKAGECONFIG[wayland]         = "--enable-wayland,--disable-wayland,wayland-native wayland wayland-protocols libdrm"
 PACKAGECONFIG[webp]            = "--enable-webp,--disable-webp,libwebp"
 PACKAGECONFIG[webrtc]          = "--enable-webrtc,--disable-webrtc,libnice"

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-bad_1.14.4.bb
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-bad_1.14.4.bb
@@ -1,0 +1,148 @@
+require gstreamer1.0-plugins.inc
+
+SRC_URI = " \
+    http://gstreamer.freedesktop.org/src/gst-plugins-bad/gst-plugins-bad-${PV}.tar.xz \
+    file://configure-allow-to-disable-libssh2.patch \
+    file://fix-maybe-uninitialized-warnings-when-compiling-with-Os.patch \
+    file://avoid-including-sys-poll.h-directly.patch \
+    file://ensure-valid-sentinels-for-gst_structure_get-etc.patch \
+    file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
+    file://0001-Makefile.am-don-t-hardcode-libtool-name-when-running.patch \
+"
+SRC_URI[md5sum] = "5d20a91d027708abcf924f6c1279dd25"
+SRC_URI[sha256sum] = "910b4e0e2e897e8b6d06767af1779d70057c309f67292f485ff988d087aa0de5"
+
+S = "${WORKDIR}/gst-plugins-bad-${PV}"
+
+LICENSE = "GPLv2+ & LGPLv2+ & LGPLv2.1+"
+LIC_FILES_CHKSUM = "file://COPYING;md5=73a5855a8119deb017f5f13cf327095d \
+                    file://COPYING.LIB;md5=21682e4e8fea52413fd26c60acb907e5 "
+
+DEPENDS += "gstreamer1.0-plugins-base"
+
+inherit gettext gobject-introspection
+
+PACKAGECONFIG ??= " \
+    ${GSTREAMER_ORC} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'bluez', '', d)} \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'directfb vulkan', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gl', '', d)} \
+    bz2 curl dash dtls hls rsvg sbc smoothstreaming sndfile ttml uvch264 webp \
+"
+
+# the gl packageconfig enables OpenGL elements that haven't been ported
+# to -base yet. They depend on the gstgl library in -base, so we do
+# not add GL dependencies here, since these are taken care of in -base.
+
+PACKAGECONFIG[assrender]       = "--enable-assrender,--disable-assrender,libass"
+PACKAGECONFIG[bluez]           = "--enable-bluez,--disable-bluez,${BLUEZ}"
+PACKAGECONFIG[bz2]             = "--enable-bz2,--disable-bz2,bzip2"
+PACKAGECONFIG[curl]            = "--enable-curl,--disable-curl,curl"
+PACKAGECONFIG[dash]            = "--enable-dash,--disable-dash,libxml2"
+PACKAGECONFIG[dc1394]          = "--enable-dc1394,--disable-dc1394,libdc1394"
+PACKAGECONFIG[directfb]        = "--enable-directfb,--disable-directfb,directfb"
+PACKAGECONFIG[dtls]            = "--enable-dtls,--disable-dtls,openssl"
+PACKAGECONFIG[faac]            = "--enable-faac,--disable-faac,faac"
+PACKAGECONFIG[faad]            = "--enable-faad,--disable-faad,faad2"
+PACKAGECONFIG[flite]           = "--enable-flite,--disable-flite,flite-alsa"
+PACKAGECONFIG[fluidsynth]      = "--enable-fluidsynth,--disable-fluidsynth,fluidsynth"
+PACKAGECONFIG[hls]             = "--enable-hls --with-hls-crypto=nettle,--disable-hls,nettle"
+PACKAGECONFIG[gl]              = "--enable-gl,--disable-gl,"
+PACKAGECONFIG[kms]             = "--enable-kms,--disable-kms,libdrm"
+PACKAGECONFIG[libde265]        = "--enable-libde265,--disable-libde265,libde265"
+PACKAGECONFIG[libmms]          = "--enable-libmms,--disable-libmms,libmms"
+PACKAGECONFIG[libssh2]         = "--enable-libssh2,--disable-libssh2,libssh2"
+PACKAGECONFIG[lcms2]           = "--enable-lcms2,--disable-lcms2,lcms"
+PACKAGECONFIG[modplug]         = "--enable-modplug,--disable-modplug,libmodplug"
+PACKAGECONFIG[msdk]            = "--enable-msdk,--disable-msdk,intel-mediasdk"
+PACKAGECONFIG[neon]            = "--enable-neon,--disable-neon,neon"
+PACKAGECONFIG[openal]          = "--enable-openal,--disable-openal,openal-soft"
+PACKAGECONFIG[opencv]          = "--enable-opencv,--disable-opencv,opencv"
+PACKAGECONFIG[openh264]        = "--enable-openh264,--disable-openh264,openh264"
+PACKAGECONFIG[openjpeg]        = "--enable-openjpeg,--disable-openjpeg,openjpeg"
+PACKAGECONFIG[openmpt]         = "--enable-openmpt,--disable-openmpt,libopenmpt"
+# the opus encoder/decoder elements are now in the -base package,
+# but the opus parser remains in -bad
+PACKAGECONFIG[opusparse]       = "--enable-opus,--disable-opus,libopus"
+PACKAGECONFIG[resindvd]        = "--enable-resindvd,--disable-resindvd,libdvdread libdvdnav"
+PACKAGECONFIG[rsvg]            = "--enable-rsvg,--disable-rsvg,librsvg"
+PACKAGECONFIG[rtmp]            = "--enable-rtmp,--disable-rtmp,rtmpdump"
+PACKAGECONFIG[sbc]             = "--enable-sbc,--disable-sbc,sbc"
+PACKAGECONFIG[smoothstreaming] = "--enable-smoothstreaming,--disable-smoothstreaming,libxml2"
+PACKAGECONFIG[sndfile]         = "--enable-sndfile,--disable-sndfile,libsndfile1"
+PACKAGECONFIG[srtp]            = "--enable-srtp,--disable-srtp,libsrtp"
+PACKAGECONFIG[tinyalsa]        = "--enable-tinyalsa,--disable-tinyalsa,tinyalsa"
+PACKAGECONFIG[ttml]            = "--enable-ttml,--disable-ttml,libxml2 pango cairo"
+PACKAGECONFIG[uvch264]         = "--enable-uvch264,--disable-uvch264,libusb1 libgudev"
+PACKAGECONFIG[voaacenc]        = "--enable-voaacenc,--disable-voaacenc,vo-aacenc"
+PACKAGECONFIG[voamrwbenc]      = "--enable-voamrwbenc,--disable-voamrwbenc,vo-amrwbenc"
+PACKAGECONFIG[vulkan]          = "--enable-vulkan,--disable-vulkan,vulkan"
+PACKAGECONFIG[wayland]         = "--enable-wayland,--disable-wayland,wayland-native wayland wayland-protocols libdrm"
+PACKAGECONFIG[webp]            = "--enable-webp,--disable-webp,libwebp"
+PACKAGECONFIG[webrtc]          = "--enable-webrtc,--disable-webrtc,libnice"
+PACKAGECONFIG[webrtcdsp]       = "--enable-webrtcdsp,--disable-webrtcdsp,webrtc-audio-processing"
+
+# these plugins have no corresponding library in OE-core or meta-openembedded:
+#   openni2 winks direct3d directsound winscreencap acm apple_media iqa
+#   android_media avc bs2b chromaprint daala dts fdkaac gme gsm kate ladspa
+#   lv2 mpeg2enc mplex musepack nvenc ofa opensles soundtouch
+#   spandsp spc teletextdec vdpau wasapi x265 zbar
+
+EXTRA_OECONF += " \
+    --enable-decklink \
+    --enable-dvb \
+    --enable-fbdev \
+    --enable-ipcpipeline \
+    --enable-netsim \
+    --enable-shm \
+    --enable-vcd \
+    --disable-acm \
+    --disable-android_media \
+    --disable-aom \
+    --disable-apple_media \
+    --disable-avc \
+    --disable-bs2b \
+    --disable-chromaprint \
+    --disable-daala \
+    --disable-direct3d \
+    --disable-directsound \
+    --disable-dts \
+    --disable-fdk_aac \
+    --disable-gme \
+    --disable-gsm \
+    --disable-iqa \
+    --disable-kate \
+    --disable-ladspa \
+    --disable-lv2 \
+    --disable-mpeg2enc \
+    --disable-mplex \
+    --disable-musepack \
+    --disable-nvenc \
+    --disable-ofa \
+    --disable-openexr \
+    --disable-openni2 \
+    --disable-opensles \
+    --disable-soundtouch \
+    --disable-spandsp \
+    --disable-spc \
+    --disable-srt \
+    --disable-teletextdec \
+    --disable-vdpau \
+    --disable-wasapi \
+    --disable-wildmidi \
+    --disable-winks \
+    --disable-winscreencap \
+    --disable-x265 \
+    --disable-zbar \
+    ${@bb.utils.contains("TUNE_FEATURES", "mx32", "--disable-yadif", "", d)} \
+"
+
+export OPENCV_PREFIX = "${STAGING_DIR_TARGET}${prefix}"
+
+ARM_INSTRUCTION_SET_armv4 = "arm"
+ARM_INSTRUCTION_SET_armv5 = "arm"
+
+FILES_${PN}-freeverb += "${datadir}/gstreamer-${LIBV}/presets/GstFreeverb.prs"
+FILES_${PN}-opencv += "${datadir}/gst-plugins-bad/${LIBV}/opencv*"
+FILES_${PN}-voamrwbenc += "${datadir}/gstreamer-${LIBV}/presets/GstVoAmrwbEnc.prs"

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/0001-Makefile.am-don-t-hardcode-libtool-name-when-running.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/0001-Makefile.am-don-t-hardcode-libtool-name-when-running.patch
@@ -1,0 +1,167 @@
+From 7022b87353a37b78bae7cf0106a4e47913bb5c97 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Thu, 5 Apr 2018 10:15:08 +0800
+Subject: [PATCH] Makefile.am: don't hardcode libtool name when running
+ introspection tools
+
+Upstream-Status: Pending [review on oe-core maillist]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+
+---
+ gst-libs/gst/allocators/Makefile.am | 2 +-
+ gst-libs/gst/app/Makefile.am        | 2 +-
+ gst-libs/gst/audio/Makefile.am      | 2 +-
+ gst-libs/gst/gl/Makefile.am         | 2 +-
+ gst-libs/gst/pbutils/Makefile.am    | 2 +-
+ gst-libs/gst/riff/Makefile.am       | 2 +-
+ gst-libs/gst/rtp/Makefile.am        | 2 +-
+ gst-libs/gst/rtsp/Makefile.am       | 2 +-
+ gst-libs/gst/sdp/Makefile.am        | 2 +-
+ gst-libs/gst/tag/Makefile.am        | 2 +-
+ gst-libs/gst/video/Makefile.am      | 2 +-
+ 11 files changed, 11 insertions(+), 11 deletions(-)
+
+diff --git a/gst-libs/gst/allocators/Makefile.am b/gst-libs/gst/allocators/Makefile.am
+index 1957d28..1ecc950 100644
+--- a/gst-libs/gst/allocators/Makefile.am
++++ b/gst-libs/gst/allocators/Makefile.am
+@@ -42,7 +42,7 @@ GstAllocators-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstallocators-@
+ 		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		--library=libgstallocators-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-allocators-@GST_API_VERSION@ \
+ 		--output $@ \
+diff --git a/gst-libs/gst/app/Makefile.am b/gst-libs/gst/app/Makefile.am
+index 52f6ad3..5bfd606 100644
+--- a/gst-libs/gst/app/Makefile.am
++++ b/gst-libs/gst/app/Makefile.am
+@@ -56,7 +56,7 @@ GstApp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstapp-@GST_API_VERSIO
+ 		--library=libgstapp-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-app-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/audio/Makefile.am b/gst-libs/gst/audio/Makefile.am
+index 2922245..7fb65f2 100644
+--- a/gst-libs/gst/audio/Makefile.am
++++ b/gst-libs/gst/audio/Makefile.am
+@@ -184,7 +184,7 @@ GstAudio-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstaudio-@GST_API_VE
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+ 		--include=GstTag-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-audio-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/gl/Makefile.am b/gst-libs/gst/gl/Makefile.am
+index 4e77e8c..3276d7f 100644
+--- a/gst-libs/gst/gl/Makefile.am
++++ b/gst-libs/gst/gl/Makefile.am
+@@ -193,7 +193,7 @@ GstGL-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstgl-@GST_API_VERSION@
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+ 		--include=GstVideo-@GST_API_VERSION@ \
+-		--libtool="${LIBTOOL}" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg gstreamer-video-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/pbutils/Makefile.am b/gst-libs/gst/pbutils/Makefile.am
+index ae51993..35a6e44 100644
+--- a/gst-libs/gst/pbutils/Makefile.am
++++ b/gst-libs/gst/pbutils/Makefile.am
+@@ -103,7 +103,7 @@ GstPbutils-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstpbutils-@GST_AP
+ 		--include=GstTag-@GST_API_VERSION@ \
+ 		--include=GstVideo-@GST_API_VERSION@ \
+ 		--include=GstAudio-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-tag-@GST_API_VERSION@ \
+ 		--pkg gstreamer-video-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/riff/Makefile.am b/gst-libs/gst/riff/Makefile.am
+index fb53f06..e66ef4f 100644
+--- a/gst-libs/gst/riff/Makefile.am
++++ b/gst-libs/gst/riff/Makefile.am
+@@ -49,7 +49,7 @@ libgstriff_@GST_API_VERSION@_la_LDFLAGS = $(GST_LIB_LDFLAGS) $(GST_ALL_LDFLAGS)
+ #		--include=GstAudio-@GST_API_VERSION@ \
+ #		--include=GstTag-@GST_API_VERSION@ \
+ #		--include=Gst-@GST_API_VERSION@ \
+-#		--libtool="$(top_builddir)/libtool" \
++#		--libtool="$(LIBTOOL)" \
+ #		--pkg gstreamer-@GST_API_VERSION@ \
+ #		--pkg gstreamer-tag-@GST_API_VERSION@ \
+ #		--pkg gstreamer-audio-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/rtp/Makefile.am b/gst-libs/gst/rtp/Makefile.am
+index a6f971d..77ebeeb 100644
+--- a/gst-libs/gst/rtp/Makefile.am
++++ b/gst-libs/gst/rtp/Makefile.am
+@@ -69,7 +69,7 @@ GstRtp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstrtp-@GST_API_VERSIO
+ 		--library=libgstrtp-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-rtp-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/rtsp/Makefile.am b/gst-libs/gst/rtsp/Makefile.am
+index ceb07f4..db9d0fd 100644
+--- a/gst-libs/gst/rtsp/Makefile.am
++++ b/gst-libs/gst/rtsp/Makefile.am
+@@ -76,7 +76,7 @@ GstRtsp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstrtsp-@GST_API_VERS
+ 		--include=Gio-2.0 \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstSdp-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gio-2.0 \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-sdp-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/sdp/Makefile.am b/gst-libs/gst/sdp/Makefile.am
+index e197e9b..6e05cc7 100644
+--- a/gst-libs/gst/sdp/Makefile.am
++++ b/gst-libs/gst/sdp/Makefile.am
+@@ -34,7 +34,7 @@ GstSdp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstsdp-@GST_API_VERSIO
+ 		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		--library=libgstsdp-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-sdp-@GST_API_VERSION@ \
+ 		--output $@ \
+diff --git a/gst-libs/gst/tag/Makefile.am b/gst-libs/gst/tag/Makefile.am
+index 0247c33..c86515b 100644
+--- a/gst-libs/gst/tag/Makefile.am
++++ b/gst-libs/gst/tag/Makefile.am
+@@ -66,7 +66,7 @@ GstTag-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgsttag-@GST_API_VERSIO
+ 		--library=libgsttag-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-tag-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/video/Makefile.am b/gst-libs/gst/video/Makefile.am
+index 9fc1ccf..0f8455f 100644
+--- a/gst-libs/gst/video/Makefile.am
++++ b/gst-libs/gst/video/Makefile.am
+@@ -124,7 +124,7 @@ GstVideo-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstvideo-@GST_API_VE
+ 		--library=libgstvideo-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-base-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-video-@GST_API_VERSION@ \

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/0001-gstreamer-gl.pc.in-don-t-append-GL_CFLAGS-to-CFLAGS.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/0001-gstreamer-gl.pc.in-don-t-append-GL_CFLAGS-to-CFLAGS.patch
@@ -1,0 +1,29 @@
+From 61a672e79c8cb1aeeeda4c968997c577ac73a8f3 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Fri, 12 May 2017 16:47:12 +0300
+Subject: [PATCH] gstreamer-gl.pc.in: don't append GL_CFLAGS to CFLAGS
+
+Dependencies' include directories should not be added in this way;
+it causes problems when cross-compiling in sysroot environments.
+
+Upstream-Status: Pending
+
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+Signed-off-by: Maxin B. John <maxin.john@intel.com>
+---
+ pkgconfig/gstreamer-gl.pc.in | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/pkgconfig/gstreamer-gl.pc.in b/pkgconfig/gstreamer-gl.pc.in
+index dc672a9..8c290ba 100644
+--- a/pkgconfig/gstreamer-gl.pc.in
++++ b/pkgconfig/gstreamer-gl.pc.in
+@@ -13,4 +13,4 @@ Version: @VERSION@
+ Requires: gstreamer-video-@GST_API_VERSION@ gstreamer-base-@GST_API_VERSION@ gstreamer-@GST_API_VERSION@
+ 
+ Libs: -L${libdir} -lgstgl-@GST_API_VERSION@
+-Cflags: -I${includedir} -I${libdir}/gstreamer-@GST_API_VERSION@/include @GL_CFLAGS@
++Cflags: -I${includedir} -I${libdir}/gstreamer-@GST_API_VERSION@/include
+-- 
+2.7.4
+

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/0002-Makefile.am-prefix-calls-to-pkg-config-with-PKG_CONF.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/0002-Makefile.am-prefix-calls-to-pkg-config-with-PKG_CONF.patch
@@ -1,0 +1,302 @@
+From 9601fc0cd6751a1affdc8717217b95931db31d7f Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Thu, 5 Apr 2018 10:26:25 +0800
+Subject: [PATCH] Makefile.am: prefix calls to pkg-config with
+ PKG_CONFIG_SYSROOT_DIR
+
+Upstream-Status: Pending [review on oe-core maillist]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+
+---
+ gst-libs/gst/allocators/Makefile.am |  4 ++--
+ gst-libs/gst/app/Makefile.am        |  4 ++--
+ gst-libs/gst/audio/Makefile.am      | 12 ++++++------
+ gst-libs/gst/gl/Makefile.am         |  8 ++++----
+ gst-libs/gst/pbutils/Makefile.am    | 12 ++++++------
+ gst-libs/gst/riff/Makefile.am       |  8 ++++----
+ gst-libs/gst/rtp/Makefile.am        |  8 ++++----
+ gst-libs/gst/rtsp/Makefile.am       |  4 ++--
+ gst-libs/gst/sdp/Makefile.am        |  4 ++--
+ gst-libs/gst/tag/Makefile.am        |  8 ++++----
+ gst-libs/gst/video/Makefile.am      |  8 ++++----
+ 11 files changed, 40 insertions(+), 40 deletions(-)
+
+diff --git a/gst-libs/gst/allocators/Makefile.am b/gst-libs/gst/allocators/Makefile.am
+index 1ecc950..d6417ac 100644
+--- a/gst-libs/gst/allocators/Makefile.am
++++ b/gst-libs/gst/allocators/Makefile.am
+@@ -39,7 +39,7 @@ GstAllocators-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstallocators-@
+ 		--c-include "gst/allocators/allocators.h" \
+ 		-I$(top_srcdir)/gst-libs \
+ 		-I$(top_builddir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		--library=libgstallocators-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--libtool="$(LIBTOOL)" \
+@@ -63,7 +63,7 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		$(INTROSPECTION_COMPILER) \
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES = $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/app/Makefile.am b/gst-libs/gst/app/Makefile.am
+index 5bfd606..6441674 100644
+--- a/gst-libs/gst/app/Makefile.am
++++ b/gst-libs/gst/app/Makefile.am
+@@ -51,8 +51,8 @@ GstApp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstapp-@GST_API_VERSIO
+ 		--c-include "gst/app/app.h" \
+ 		-I$(top_srcdir)/gst-libs \
+ 		-I$(top_builddir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--library=libgstapp-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+diff --git a/gst-libs/gst/audio/Makefile.am b/gst-libs/gst/audio/Makefile.am
+index 7fb65f2..5379f79 100644
+--- a/gst-libs/gst/audio/Makefile.am
++++ b/gst-libs/gst/audio/Makefile.am
+@@ -174,12 +174,12 @@ GstAudio-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstaudio-@GST_API_VE
+ 		-I$(top_srcdir)/gst-libs \
+ 		-I$(top_builddir)/gst-libs \
+ 		--c-include "gst/audio/audio.h" \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--add-include-path="$(top_builddir)/gst-libs/gst/tag/" \
+ 		--library=libgstaudio-@GST_API_VERSION@.la \
+-		--library-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-@GST_API_VERSION@` \
+-		--library-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-base-@GST_API_VERSION@` \
++		--library-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-@GST_API_VERSION@` \
++		--library-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-base-@GST_API_VERSION@` \
+ 		--library-path="$(top_builddir)/gst-libs/gst/tag/" \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+@@ -208,8 +208,8 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+ 		--includedir="$(top_builddir)/gst-libs/gst/tag/" \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES += $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/gl/Makefile.am b/gst-libs/gst/gl/Makefile.am
+index 3276d7f..0cdfe26 100644
+--- a/gst-libs/gst/gl/Makefile.am
++++ b/gst-libs/gst/gl/Makefile.am
+@@ -186,9 +186,9 @@ GstGL-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstgl-@GST_API_VERSION@
+ 		$(GST_PLUGINS_BASE_CFLAGS) \
+ 		$(GL_CFLAGS) \
+ 		--add-include-path="$(top_builddir)/gst-libs/gst/video/" \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--library-path="$(top_builddir)/gst-libs/gst/video/" \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--library=libgstgl-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+@@ -218,8 +218,8 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+ 		--includedir="$(top_builddir)/gst-libs/gst/video/" \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES = $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/pbutils/Makefile.am b/gst-libs/gst/pbutils/Makefile.am
+index 35a6e44..49d6894 100644
+--- a/gst-libs/gst/pbutils/Makefile.am
++++ b/gst-libs/gst/pbutils/Makefile.am
+@@ -88,14 +88,14 @@ GstPbutils-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstpbutils-@GST_AP
+ 		--c-include "gst/pbutils/pbutils.h" \
+ 		-I$(top_srcdir)/gst-libs \
+ 		-I$(top_builddir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--add-include-path="$(top_builddir)/gst-libs/gst/tag/" \
+ 		--add-include-path="$(top_builddir)/gst-libs/gst/video/" \
+ 		--add-include-path="$(top_builddir)/gst-libs/gst/audio/" \
+ 		--library=libgstpbutils-@GST_API_VERSION@.la \
+-		--library-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-@GST_API_VERSION@` \
+-		--library-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-base-@GST_API_VERSION@` \
++		--library-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-@GST_API_VERSION@` \
++		--library-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=libdir gstreamer-base-@GST_API_VERSION@` \
+ 		--library-path="$(top_builddir)/gst-libs/gst/tag/" \
+ 		--library-path="$(top_builddir)/gst-libs/gst/video/" \
+ 		--library-path="$(top_builddir)/gst-libs/gst/audio/" \
+@@ -128,8 +128,8 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		$(INTROSPECTION_COMPILER) \
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--includedir="$(top_builddir)/gst-libs/gst/tag/" \
+ 		--includedir="$(top_builddir)/gst-libs/gst/video/" \
+ 		--includedir="$(top_builddir)/gst-libs/gst/audio/" \
+diff --git a/gst-libs/gst/riff/Makefile.am b/gst-libs/gst/riff/Makefile.am
+index e66ef4f..c8c588a 100644
+--- a/gst-libs/gst/riff/Makefile.am
++++ b/gst-libs/gst/riff/Makefile.am
+@@ -43,8 +43,8 @@ libgstriff_@GST_API_VERSION@_la_LDFLAGS = $(GST_LIB_LDFLAGS) $(GST_ALL_LDFLAGS)
+ #		--c-include "gst/riff/riff.h" \
+ #		--add-include-path=$(builddir)/../tag \
+ #		--add-include-path=$(builddir)/../audio \
+-#		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-#		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++#		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++#		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ #		--library=libgstriff-@GST_API_VERSION@.la \
+ #		--include=GstAudio-@GST_API_VERSION@ \
+ #		--include=GstTag-@GST_API_VERSION@ \
+@@ -75,8 +75,8 @@ libgstriff_@GST_API_VERSION@_la_LDFLAGS = $(GST_LIB_LDFLAGS) $(GST_ALL_LDFLAGS)
+ #		--includedir=$(builddir) \
+ #		--includedir=$(builddir)/../tag \
+ #		--includedir=$(builddir)/../audio \
+-#		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-#		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++#		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++#		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ #		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ #
+ #CLEANFILES = $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/rtp/Makefile.am b/gst-libs/gst/rtp/Makefile.am
+index 77ebeeb..9aee788 100644
+--- a/gst-libs/gst/rtp/Makefile.am
++++ b/gst-libs/gst/rtp/Makefile.am
+@@ -64,8 +64,8 @@ GstRtp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstrtp-@GST_API_VERSIO
+ 		--c-include "gst/rtp/rtp.h" \
+ 		-I$(top_builddir)/gst-libs \
+ 		-I$(top_srcdir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--library=libgstrtp-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+@@ -92,8 +92,8 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		$(INTROSPECTION_COMPILER) \
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES += $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/rtsp/Makefile.am b/gst-libs/gst/rtsp/Makefile.am
+index db9d0fd..79027cb 100644
+--- a/gst-libs/gst/rtsp/Makefile.am
++++ b/gst-libs/gst/rtsp/Makefile.am
+@@ -71,7 +71,7 @@ GstRtsp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstrtsp-@GST_API_VERS
+ 		-I$(top_builddir)/gst-libs \
+ 		-I$(top_srcdir)/gst-libs \
+ 		--add-include-path=$(builddir)/../sdp \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		--library=libgstrtsp-@GST_API_VERSION@.la \
+ 		--include=Gio-2.0 \
+ 		--include=Gst-@GST_API_VERSION@ \
+@@ -101,7 +101,7 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+ 		--includedir=$(builddir)/../sdp \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES += $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/sdp/Makefile.am b/gst-libs/gst/sdp/Makefile.am
+index 6e05cc7..c7cf514 100644
+--- a/gst-libs/gst/sdp/Makefile.am
++++ b/gst-libs/gst/sdp/Makefile.am
+@@ -31,7 +31,7 @@ GstSdp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstsdp-@GST_API_VERSIO
+ 		--warn-all \
+ 		--c-include "gst/sdp/sdp.h" \
+ 		-I$(top_srcdir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		--library=libgstsdp-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--libtool="$(LIBTOOL)" \
+@@ -55,7 +55,7 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		$(INTROSPECTION_COMPILER) \
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES = $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/tag/Makefile.am b/gst-libs/gst/tag/Makefile.am
+index c86515b..363e6d2 100644
+--- a/gst-libs/gst/tag/Makefile.am
++++ b/gst-libs/gst/tag/Makefile.am
+@@ -61,8 +61,8 @@ GstTag-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgsttag-@GST_API_VERSIO
+ 		--c-include "gst/tag/tag.h" \
+ 		-I$(top_srcdir)/gst-libs \
+ 		-I$(top_builddir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--library=libgsttag-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+@@ -89,8 +89,8 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		$(INTROSPECTION_COMPILER) \
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES += $(BUILT_GIRSOURCES) $(typelibs_DATA)
+diff --git a/gst-libs/gst/video/Makefile.am b/gst-libs/gst/video/Makefile.am
+index 0f8455f..8c9955c 100644
+--- a/gst-libs/gst/video/Makefile.am
++++ b/gst-libs/gst/video/Makefile.am
+@@ -119,8 +119,8 @@ GstVideo-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstvideo-@GST_API_VE
+ 		--c-include "gst/video/video.h" \
+ 		-I$(top_srcdir)/gst-libs \
+ 		-I$(top_builddir)/gst-libs \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--add-include-path=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		--library=libgstvideo-@GST_API_VERSION@.la \
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstBase-@GST_API_VERSION@ \
+@@ -147,8 +147,8 @@ typelibs_DATA = $(BUILT_GIRSOURCES:.gir=.typelib)
+ 		$(INTROSPECTION_COMPILER) \
+ 		--includedir=$(srcdir) \
+ 		--includedir=$(builddir) \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
+-		--includedir=`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \
++		--includedir=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-base-@GST_API_VERSION@` \
+ 		$(INTROSPECTION_COMPILER_OPTS) $< -o $(@F)
+ 
+ CLEANFILES += $(BUILT_GIRSOURCES) $(typelibs_DATA)

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/0003-riff-add-missing-include-directories-when-calling-in.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/0003-riff-add-missing-include-directories-when-calling-in.patch
@@ -1,0 +1,26 @@
+From b9765efb1696e3e2e79f2955f759be199fe34882 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Mon, 26 Oct 2015 17:29:37 +0200
+Subject: [PATCH] riff: add missing include directories when calling
+ introspection scanner
+
+Upstream-Status: Pending [review on oe-core maillist]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+
+---
+ gst-libs/gst/riff/Makefile.am | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/gst-libs/gst/riff/Makefile.am b/gst-libs/gst/riff/Makefile.am
+index c8c588a..c096453 100644
+--- a/gst-libs/gst/riff/Makefile.am
++++ b/gst-libs/gst/riff/Makefile.am
+@@ -41,6 +41,8 @@ libgstriff_@GST_API_VERSION@_la_LDFLAGS = $(GST_LIB_LDFLAGS) $(GST_ALL_LDFLAGS)
+ #		--strip-prefix=Gst \
+ #		--warn-all \
+ #		--c-include "gst/riff/riff.h" \
++#               -I$(top_srcdir)/gst-libs \
++#               -I$(top_builddir)/gst-libs \
+ #		--add-include-path=$(builddir)/../tag \
+ #		--add-include-path=$(builddir)/../audio \
+ #		--add-include-path=$(PKG_CONFIG_SYSROOT_DIR)`PKG_CONFIG_PATH="$(GST_PKG_CONFIG_PATH)" $(PKG_CONFIG) --variable=girdir gstreamer-@GST_API_VERSION@` \

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/0003-ssaparse-enhance-SSA-text-lines-parsing.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/0003-ssaparse-enhance-SSA-text-lines-parsing.patch
@@ -1,0 +1,227 @@
+From 918c96b24d10f61b7455b4cef3bab490849d0d77 Mon Sep 17 00:00:00 2001
+From: Mingke Wang <mingke.wang@freescale.com>
+Date: Thu, 19 Mar 2015 14:17:10 +0800
+Subject: [PATCH] ssaparse: enhance SSA text lines parsing.
+
+some parser will pass in the original ssa text line which starts with "Dialog:"
+and there's are maybe multiple Dialog lines in one input buffer.
+
+Upstream-Status: Submitted [https://bugzilla.gnome.org/show_bug.cgi?id=747496]
+
+Signed-off-by: Mingke Wang <mingke.wang@freescale.com>
+
+---
+ gst/subparse/gstssaparse.c | 150 ++++++++++++++++++++++++++++++++++++++++-----
+ 1 file changed, 134 insertions(+), 16 deletions(-)
+ mode change 100644 => 100755 gst/subparse/gstssaparse.c
+
+diff --git a/gst/subparse/gstssaparse.c b/gst/subparse/gstssaparse.c
+old mode 100644
+new mode 100755
+index c849c08..4b9636c
+--- a/gst/subparse/gstssaparse.c
++++ b/gst/subparse/gstssaparse.c
+@@ -262,6 +262,7 @@ gst_ssa_parse_remove_override_codes (GstSsaParse * parse, gchar * txt)
+  * gst_ssa_parse_push_line:
+  * @parse: caller element
+  * @txt: text to push
++ * @size: text size need to be parse
+  * @start: timestamp for the buffer
+  * @duration: duration for the buffer
+  *
+@@ -271,27 +272,133 @@ gst_ssa_parse_remove_override_codes (GstSsaParse * parse, gchar * txt)
+  * Returns: result of the push of the created buffer
+  */
+ static GstFlowReturn
+-gst_ssa_parse_push_line (GstSsaParse * parse, gchar * txt,
++gst_ssa_parse_push_line (GstSsaParse * parse, gchar * txt, gint size,
+     GstClockTime start, GstClockTime duration)
+ {
+   GstFlowReturn ret;
+   GstBuffer *buf;
+-  gchar *t, *escaped;
++  gchar *t, *text, *p, *escaped, *p_start, *p_end;
+   gint num, i, len;
++  GstClockTime start_time = G_MAXUINT64, end_time = 0;
+ 
+-  num = atoi (txt);
+-  GST_LOG_OBJECT (parse, "Parsing line #%d at %" GST_TIME_FORMAT,
+-      num, GST_TIME_ARGS (start));
+-
+-  /* skip all non-text fields before the actual text */
++  p = text = g_malloc(size + 1);
++  *p = '\0';
+   t = txt;
+-  for (i = 0; i < 8; ++i) {
+-    t = strchr (t, ',');
++
++  /* there are may have multiple dialogue lines at a time */
++  while (*t) {
++    /* ignore leading white space characters */
++    while (isspace(*t))
++      t++;
++
++    /* ignore Format: and Style: lines */
++    if (strncmp(t, "Format:", 7) == 0 || strncmp(t, "Style:", 6) == 0) {
++      while (*t != '\0' && *t != '\n') {
++        t++;
++      }
++    }
++
++    if (*t == '\0')
++      break;
++
++    /* continue with next line */
++    if (*t == '\n') {
++      t++;
++      continue;
++    }
++
++    if(strncmp(t, "Dialogue:", 9) != 0) {
++      /* not started with "Dialogue:", it must be a line trimmed by demuxer */
++      num = atoi (t);
++      GST_LOG_OBJECT (parse, "Parsing line #%d at %" GST_TIME_FORMAT,
++          num, GST_TIME_ARGS (start));
++
++      /* skip all non-text fields before the actual text */
++      for (i = 0; i < 8; ++i) {
++        t = strchr (t, ',');
++        if (t == NULL)
++          break;
++        ++t;
++      }
++    } else {
++      /* started with "Dialogue:", update timestamp and duration */
++      /* time format are like Dialog:Mark,0:00:01.02,0:00:03.04,xx,xxx,... */
++      guint hour, min, sec, msec, len;
++      GstClockTime tmp;
++      gchar t_str[12] = {0};
++
++      /* find the first ',' */
++      p_start = strchr (t, ',');
++      if (p_start)
++        p_end = strchr (++p_start, ',');
++
++      if (p_start && p_end) {
++        /* copy text between first ',' and second ',' */
++        strncpy(t_str, p_start, p_end - p_start);
++        if (sscanf (t_str, "%u:%u:%u.%u", &hour, &min, &sec, &msec) == 4) {
++          tmp = ((hour*3600) + (min*60) + sec) * GST_SECOND + msec*GST_MSECOND;
++          GST_DEBUG_OBJECT (parse, "Get start time:%02d:%02d:%02d:%03d\n",
++              hour, min, sec, msec);
++          if (start_time > tmp)
++            start_time = tmp;
++        } else {
++          GST_WARNING_OBJECT (parse,
++              "failed to parse ssa start timestamp string :%s", t_str);
++        }
++
++        p_start = p_end;
++        p_end = strchr (++p_start, ',');
++        if (p_end) {
++          /* copy text between second ',' and third ',' */
++          strncpy(t_str, p_start, p_end - p_start);
++          if (sscanf (t_str, "%u:%u:%u.%u", &hour, &min, &sec, &msec) == 4) {
++            tmp = ((hour*3600) + (min*60) + sec)*GST_SECOND + msec*GST_MSECOND;
++            GST_DEBUG_OBJECT(parse, "Get end time:%02d:%02d:%02d:%03d\n",
++                hour, min, sec, msec);
++            if (end_time < tmp)
++              end_time = tmp;
++          } else {
++            GST_WARNING_OBJECT (parse,
++                "failed to parse ssa end timestamp string :%s", t_str);
++          }
++        }
++      }
++
++      /* now skip all non-text fields before the actual text */
++      for (i = 0; i <= 8; ++i) {
++        t = strchr (t, ',');
++        if (t == NULL)
++          break;
++        ++t;
++      }
++    }
++
++    /* line end before expected number of ',', not a Dialogue line */
+     if (t == NULL)
+-      return GST_FLOW_ERROR;
+-    ++t;
++      break;
++
++    /* if not the first line, and the last character of previous line is '\0',
++     * then replace it with '\N' */
++    if (p != text && *p == '\0') {
++      *p++ = '\\';
++      *p++ = 'N';
++    }
++
++    /* copy all actual text of this line */
++    while ((*t != '\0') && (*t != '\n'))
++      *p++ = *t++;
++
++    /* add a terminator at the end */
++    *p = '\0';
++  }
++
++  /* not valid text found in this buffer return OK to let caller unref buffer */
++  if (strlen(text) <= 0) {
++    GST_WARNING_OBJECT (parse, "Not valid text found in this buffer\n");
++    return GST_FLOW_ERROR;
+   }
+ 
++  t = text;
+   GST_LOG_OBJECT (parse, "Text : %s", t);
+ 
+   if (gst_ssa_parse_remove_override_codes (parse, t)) {
+@@ -309,13 +416,22 @@ gst_ssa_parse_push_line (GstSsaParse * parse, gchar * txt,
+   gst_buffer_fill (buf, 0, escaped, len + 1);
+   gst_buffer_set_size (buf, len);
+   g_free (escaped);
++  g_free(t);
++
++  if (start_time != G_MAXUINT64)
++    GST_BUFFER_TIMESTAMP (buf) = start_time;
++  else
++    GST_BUFFER_TIMESTAMP (buf) = start;
+ 
+-  GST_BUFFER_TIMESTAMP (buf) = start;
+-  GST_BUFFER_DURATION (buf) = duration;
++  if (end_time > start_time)
++    GST_BUFFER_DURATION (buf) = end_time - start_time;
++  else
++    GST_BUFFER_DURATION (buf) = duration;
+ 
+   GST_LOG_OBJECT (parse, "Pushing buffer with timestamp %" GST_TIME_FORMAT
+-      " and duration %" GST_TIME_FORMAT, GST_TIME_ARGS (start),
+-      GST_TIME_ARGS (duration));
++      " and duration %" GST_TIME_FORMAT,
++      GST_TIME_ARGS (GST_BUFFER_TIMESTAMP (buf)),
++      GST_TIME_ARGS (GST_BUFFER_DURATION (buf)));
+ 
+   ret = gst_pad_push (parse->srcpad, buf);
+ 
+@@ -335,6 +451,7 @@ gst_ssa_parse_chain (GstPad * sinkpad, GstObject * parent, GstBuffer * buf)
+   GstClockTime ts;
+   gchar *txt;
+   GstMapInfo map;
++  gint size;
+ 
+   if (G_UNLIKELY (!parse->framed))
+     goto not_framed;
+@@ -352,13 +469,14 @@ gst_ssa_parse_chain (GstPad * sinkpad, GstObject * parent, GstBuffer * buf)
+   /* make double-sure it's 0-terminated and all */
+   gst_buffer_map (buf, &map, GST_MAP_READ);
+   txt = g_strndup ((gchar *) map.data, map.size);
++  size = map.size;
+   gst_buffer_unmap (buf, &map);
+ 
+   if (txt == NULL)
+     goto empty_text;
+ 
+   ts = GST_BUFFER_TIMESTAMP (buf);
+-  ret = gst_ssa_parse_push_line (parse, txt, ts, GST_BUFFER_DURATION (buf));
++  ret = gst_ssa_parse_push_line (parse, txt, size, ts, GST_BUFFER_DURATION (buf));
+ 
+   if (ret != GST_FLOW_OK && GST_CLOCK_TIME_IS_VALID (ts)) {
+     GstSegment segment;

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/0004-rtsp-drop-incorrect-reference-to-gstreamer-sdp-in-Ma.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/0004-rtsp-drop-incorrect-reference-to-gstreamer-sdp-in-Ma.patch
@@ -1,0 +1,25 @@
+From 53b5868491cf99ee797192395dbfeb69df23edd2 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Mon, 26 Oct 2015 17:30:14 +0200
+Subject: [PATCH] rtsp: drop incorrect reference to gstreamer-sdp in
+ Makefile.am
+
+Upstream-Status: Pending [review on oe-core maillist]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+
+---
+ gst-libs/gst/rtsp/Makefile.am | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/gst-libs/gst/rtsp/Makefile.am b/gst-libs/gst/rtsp/Makefile.am
+index 79027cb..2987e23 100644
+--- a/gst-libs/gst/rtsp/Makefile.am
++++ b/gst-libs/gst/rtsp/Makefile.am
+@@ -79,7 +79,6 @@ GstRtsp-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstrtsp-@GST_API_VERS
+ 		--libtool="$(LIBTOOL)" \
+ 		--pkg gio-2.0 \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+-		--pkg gstreamer-sdp-@GST_API_VERSION@ \
+ 		--pkg-export gstreamer-rtsp-@GST_API_VERSION@ \
+ 		--add-init-section="$(INTROSPECTION_INIT)" \
+ 		--output $@ \

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/0009-glimagesink-Downrank-to-marginal.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/0009-glimagesink-Downrank-to-marginal.patch
@@ -1,0 +1,32 @@
+From c6b37a80806f9128de47f1ccc3f2354f8d436bb6 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Thu, 24 Sep 2015 19:47:32 +0300
+Subject: [PATCH] glimagesink: Downrank to marginal
+
+On desktop, where there is good OpenGL, xvimagesink will come up first,
+on other platforms, OpenGL can't be trusted because it's either software (like
+in a VM) or broken (like on embedded)., so let ximagesink come above.
+
+Upstream-Status: Submitted [https://bugzilla.gnome.org/show_bug.cgi?id=751684]
+
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ ext/gl/gstopengl.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ext/gl/gstopengl.c b/ext/gl/gstopengl.c
+index a4b2540..0ccaacd 100644
+--- a/ext/gl/gstopengl.c
++++ b/ext/gl/gstopengl.c
+@@ -118,7 +118,7 @@ plugin_init (GstPlugin * plugin)
+ #endif
+ 
+   if (!gst_element_register (plugin, "glimagesink",
+-          GST_RANK_SECONDARY, gst_gl_image_sink_bin_get_type ())) {
++          GST_RANK_MARGINAL, gst_gl_image_sink_bin_get_type ())) {
+     return FALSE;
+   }
+ 
+-- 
+2.1.4
+

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/0010-gl-Add-switch-for-explicitely-enabling-disabling-GBM.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/0010-gl-Add-switch-for-explicitely-enabling-disabling-GBM.patch
@@ -1,0 +1,70 @@
+From a1b59ca6b1781442f37ffc1b697635db126b3a22 Mon Sep 17 00:00:00 2001
+From: Carlos Rafael Giani <dv@pseudoterminal.org>
+Date: Thu, 19 Jul 2018 10:30:54 +0200
+Subject: [PATCH] gl: Add switch for explicitely enabling/disabling GBM support
+
+Upstream-Status: Submitted [https://bugzilla.gnome.org/show_bug.cgi?id=796833]
+
+Signed-off-by: Carlos Rafael Giani <dv@pseudoterminal.org>
+---
+ m4/gst-gl.m4 | 30 ++++++++++++++++++++++++++++--
+ 1 file changed, 28 insertions(+), 2 deletions(-)
+
+diff --git a/m4/gst-gl.m4 b/m4/gst-gl.m4
+index 1e9724094..aca5295cc 100644
+--- a/m4/gst-gl.m4
++++ b/m4/gst-gl.m4
+@@ -117,6 +117,15 @@ AC_ARG_ENABLE([dispmanx],
+        *) AC_MSG_ERROR([bad value ${enableval} for --enable-dispmanx]) ;;
+      esac],[NEED_DISPMANX=auto])
+ 
++AC_ARG_ENABLE([gbm],
++     [  --enable-gbm        Enable Mesa3D GBM support (requires EGL) @<:@default=auto@:>@],
++     [case "${enableval}" in
++       yes)  NEED_GBM=yes ;;
++       no)   NEED_GBM=no ;;
++       auto) NEED_GBM=auto ;;
++       *) AC_MSG_ERROR([bad value ${enableval} for --enable-gbm]) ;;
++     esac],[NEED_GBM=auto])
++
+ AG_GST_PKG_CHECK_MODULES(X11_XCB, x11-xcb)
+ save_CPPFLAGS="$CPPFLAGS"
+ save_LIBS="$LIBS"
+@@ -172,15 +181,32 @@ case $host in
+         AC_CHECK_LIB([EGL], [fbGetDisplay], [HAVE_VIV_FB_EGL=yes])
+     fi
+ 
+-    if test "x$HAVE_EGL" = "xyes"; then
++    if test "x$NEED_GBM" != "xno"; then
++      if test "x$HAVE_EGL" = "xyes"; then
+         PKG_CHECK_MODULES(DRM, libdrm >= 2.4.55, HAVE_DRM=yes, HAVE_DRM=no)
+         AC_SUBST(DRM_CFLAGS)
+         AC_SUBST(DRM_LIBS)
++        if test "x$NEED_GBM" = "xyes"; then
++          if test "x$HAVE_DRM" = "xno"; then
++            AC_MSG_ERROR([GBM support requested but libdrm is not available])
++          fi
++          if test "x$HAVE_GUDEV" = "xno"; then
++            AC_MSG_ERROR([GBM support requested but gudev is not available])
++          fi
++        fi
+         if test "x$HAVE_DRM" = "xyes" -a "x$HAVE_GUDEV" = "xyes"; then
+           PKG_CHECK_MODULES(GBM, gbm, HAVE_GBM_EGL=yes, HAVE_GBM_EGL=no)
++          if test "x$HAVE_GBM_EGL" = "xno" -a "x$NEED_GBM" = "xyes"; then
++            AC_MSG_ERROR([GBM support requested but gbm library is not available])
++          fi
+           AC_SUBST(GBM_CFLAGS)
+           AC_SUBST(GBM_LIBS)
+-       fi
++        fi
++      elif test "x$NEED_GBM" = "xyes"; then
++        AC_MSG_ERROR([GBM support requested but EGL is not available])
++      else
++        AC_MSG_NOTICE([GBM support requested but EGL is not available; not enabling GBM support])
++      fi
+     fi
+ 
+     dnl FIXME: Mali EGL depends on GLESv1 or GLESv2
+-- 
+2.17.1
+

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/0011-gl-Add-switches-for-explicitely-enabling-disabling-P.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/0011-gl-Add-switches-for-explicitely-enabling-disabling-P.patch
@@ -1,0 +1,109 @@
+From 092aadfc1df69c46d920b0cd39f98d363d6988b3 Mon Sep 17 00:00:00 2001
+From: Carlos Rafael Giani <dv@pseudoterminal.org>
+Date: Thu, 19 Jul 2018 11:16:05 +0200
+Subject: [PATCH] gl: Add switches for explicitely enabling/disabling PNG and
+ JPEG support
+
+Upstream-Status: Submitted [https://bugzilla.gnome.org/show_bug.cgi?id=796833]
+
+Signed-off-by: Carlos Rafael Giani <dv@pseudoterminal.org>
+---
+ m4/gst-gl.m4 | 66 ++++++++++++++++++++++++++++++++++++----------------
+ 1 file changed, 46 insertions(+), 20 deletions(-)
+
+diff --git a/m4/gst-gl.m4 b/m4/gst-gl.m4
+index 20b2233de..f8809981c 100644
+--- a/m4/gst-gl.m4
++++ b/m4/gst-gl.m4
+@@ -126,6 +126,24 @@ AC_ARG_ENABLE([gbm],
+        *) AC_MSG_ERROR([bad value ${enableval} for --enable-gbm]) ;;
+      esac],[NEED_GBM=auto])
+ 
++AC_ARG_ENABLE([png],
++     [  --enable-png        Enable libpng support @<:@default=auto@:>@],
++     [case "${enableval}" in
++       yes)  NEED_PNG=yes ;;
++       no)   NEED_PNG=no ;;
++       auto) NEED_PNG=auto ;;
++       *) AC_MSG_ERROR([bad value ${enableval} for --enable-png]) ;;
++     esac],[NEED_PNG=auto])
++
++AC_ARG_ENABLE([jpeg],
++     [  --enable-jpeg        Enable libjpeg support @<:@default=auto@:>@],
++     [case "${enableval}" in
++       yes)  NEED_JPEG=yes ;;
++       no)   NEED_JPEG=no ;;
++       auto) NEED_JPEG=auto ;;
++       *) AC_MSG_ERROR([bad value ${enableval} for --enable-jpeg]) ;;
++     esac],[NEED_JPEG=auto])
++
+ AG_GST_PKG_CHECK_MODULES(X11_XCB, x11-xcb)
+ save_CPPFLAGS="$CPPFLAGS"
+ save_LIBS="$LIBS"
+@@ -1043,9 +1061,13 @@ dnl Needed by plugins that use g_module_*() API
+ PKG_CHECK_MODULES(GMODULE_NO_EXPORT, gmodule-no-export-2.0)
+ 
+ dnl libpng is optional
+-PKG_CHECK_MODULES(LIBPNG, libpng >= 1.0, HAVE_PNG=yes, HAVE_PNG=no)
+-if test "x$HAVE_PNG" = "xyes"; then
+-  AC_DEFINE(HAVE_PNG, [1] , [Use libpng])
++if test "x$NEED_PNG" != "xno"; then
++  PKG_CHECK_MODULES(LIBPNG, libpng >= 1.0, HAVE_PNG=yes, HAVE_PNG=no)
++  if test "x$HAVE_PNG" = "xyes"; then
++    AC_DEFINE(HAVE_PNG, [1] , [Use libpng])
++  elif test "x$NEED_PNG" = "xyes"; then
++    AC_MSG_ERROR([libpng support requested but libpng is not available])
++  fi
+ fi
+ AC_SUBST(HAVE_PNG)
+ AC_SUBST(LIBPNG_LIBS)
+@@ -1053,25 +1075,29 @@ AC_SUBST(LIBPNG_CFLAGS)
+ 
+ dnl libjpeg is optional
+ AC_ARG_WITH(jpeg-mmx, [  --with-jpeg-mmx, path to MMX'ified JPEG library])
+-OLD_LIBS="$LIBS"
+-if test x$with_jpeg_mmx != x; then
+-  LIBS="$LIBS -L$with_jpeg_mmx"
+-fi
+-AC_CHECK_LIB(jpeg-mmx, jpeg_set_defaults, HAVE_JPEG="yes", HAVE_JPEG="no")
+-JPEG_LIBS="$LIBS -ljpeg-mmx"
+-LIBS="$OLD_LIBS"
+-if test x$HAVE_JPEG != xyes; then
+-  JPEG_LIBS="-ljpeg"
+-  AC_CHECK_LIB(jpeg, jpeg_set_defaults, HAVE_JPEG="yes", HAVE_JPEG="no")
+-fi
++if test "x$NEED_JPEG" != "xno"; then
++  OLD_LIBS="$LIBS"
++  if test x$with_jpeg_mmx != x; then
++    LIBS="$LIBS -L$with_jpeg_mmx"
++  fi
++  AC_CHECK_LIB(jpeg-mmx, jpeg_set_defaults, HAVE_JPEG="yes", HAVE_JPEG="no")
++  JPEG_LIBS="$LIBS -ljpeg-mmx"
++  LIBS="$OLD_LIBS"
++  if test x$HAVE_JPEG != xyes; then
++    JPEG_LIBS="-ljpeg"
++    AC_CHECK_LIB(jpeg, jpeg_set_defaults, HAVE_JPEG="yes", HAVE_JPEG="no")
++  fi
+ 
+-if test x$HAVE_JPEG = xyes; then
+-  AC_DEFINE(HAVE_JPEG, [1], [Use libjpeg])
+-else
+-  JPEG_LIBS=
++  if test x$HAVE_JPEG = xyes; then
++    AC_DEFINE(HAVE_JPEG, [1], [Use libjpeg])
++  elif test "x$NEED_JPEG" = "xyes"; then
++    AC_MSG_ERROR([libjpeg support requested but libjpeg is not available])
++  else
++    JPEG_LIBS=
++  fi
++  AC_SUBST(JPEG_LIBS)
++  AC_SUBST(HAVE_JPEG)
+ fi
+-AC_SUBST(JPEG_LIBS)
+-AC_SUBST(HAVE_JPEG)
+ ])
+ 
+ dnl --------------------------------------------------------------------------
+-- 
+2.17.1
+

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/CVE-2019-9928.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/CVE-2019-9928.patch
@@ -1,0 +1,33 @@
+From f672277509705c4034bc92a141eefee4524d15aa Mon Sep 17 00:00:00 2001
+From: Tobias Ronge <tobiasr@axis.com>
+Date: Thu, 14 Mar 2019 10:12:27 +0100
+Subject: [PATCH] gstrtspconnection: Security loophole making heap overflow
+
+The former code allowed an attacker to create a heap overflow by
+sending a longer than allowed session id in a response and including a
+semicolon to change the maximum length. With this change, the parser
+will never go beyond 512 bytes.
+
+Upstream-Status: Backport
+CVE: CVE-2019-9928
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+---
+ gst-libs/gst/rtsp/gstrtspconnection.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gst-libs/gst/rtsp/gstrtspconnection.c b/gst-libs/gst/rtsp/gstrtspconnection.c
+index a6755bedd..c0429064a 100644
+--- a/gst-libs/gst/rtsp/gstrtspconnection.c
++++ b/gst-libs/gst/rtsp/gstrtspconnection.c
+@@ -2461,7 +2461,7 @@ build_next (GstRTSPBuilder * builder, GstRTSPMessage * message,
+           maxlen = sizeof (conn->session_id) - 1;
+           /* the sessionid can have attributes marked with ;
+            * Make sure we strip them */
+-          for (i = 0; session_id[i] != '\0'; i++) {
++          for (i = 0; i < maxlen && session_id[i] != '\0'; i++) {
+             if (session_id[i] == ';') {
+               maxlen = i;
+               /* parse timeout */
+-- 
+2.21.0
+

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/get-caps-from-src-pad-when-query-caps.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/get-caps-from-src-pad-when-query-caps.patch
@@ -1,0 +1,42 @@
+From 41de2ec64ab06bb58c82c1659adaa3811bc5bcf8 Mon Sep 17 00:00:00 2001
+From: zhouming <b42586@freescale.com>
+Date: Wed, 14 May 2014 10:16:20 +0800
+Subject: [PATCH] ENGR00312515: get caps from src pad when query caps
+
+https://bugzilla.gnome.org/show_bug.cgi?id=728312
+
+Upstream-Status: Pending
+
+Signed-off-by: zhouming <b42586@freescale.com>
+
+---
+ gst-libs/gst/tag/gsttagdemux.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+ mode change 100644 => 100755 gst-libs/gst/tag/gsttagdemux.c
+
+diff --git a/gst-libs/gst/tag/gsttagdemux.c b/gst-libs/gst/tag/gsttagdemux.c
+old mode 100644
+new mode 100755
+index 8a127c8..71c5d78
+--- a/gst-libs/gst/tag/gsttagdemux.c
++++ b/gst-libs/gst/tag/gsttagdemux.c
+@@ -1759,6 +1759,19 @@ gst_tag_demux_pad_query (GstPad * pad, GstObject * parent, GstQuery * query)
+       }
+       break;
+     }
++    case GST_QUERY_CAPS:
++    {
++
++      /* We can hijack caps query if we typefind already */
++      if (demux->priv->src_caps) {
++        gst_query_set_caps_result (query, demux->priv->src_caps);
++        res = TRUE;
++      } else {
++        res = gst_pad_query_default (pad, parent, query);
++      }
++      break;
++    }
++
+     default:
+       res = gst_pad_query_default (pad, parent, query);
+       break;

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/link-with-libvchostif.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/link-with-libvchostif.patch
@@ -1,0 +1,45 @@
+From 9866f51e5e0913f1e453eb574618bf7432f38cb6 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Wed, 11 Apr 2018 10:46:33 +0800
+Subject: [PATCH] Add -lvchostif to link when using -lEGL on rpi
+
+This is required because libEGL from userland uses sybols
+from this library.
+
+lib/libEGL.so.1.0.0                                                                                                                                                                                                                              121: 00000000     0 FUNC    GLOBAL DEFAULT  UND vc_dispmanx_element_add
+  1552: 00000000     0 FUNC    GLOBAL DEFAULT  UND vc_dispmanx_element_add
+
+These symbols are provided by libvchostif as seen below
+
+lib/libvchostif.so
+   252: 0000b161   192 FUNC    GLOBAL DEFAULT    9 vc_dispmanx_element_add
+   809: 0000b161   192 FUNC    GLOBAL DEFAULT    9 vc_dispmanx_element_add
+
+With this explicit link, plugins fail during runtime
+
+(gst-plugin-scanner:571): GStreamer-WARNING **: Failed to load plugin '/usr/lib/gstreamer-1.0/libgstomx.so': Error relocating /usr/lib/libgstgl-1.0.so.0: vc_dispmanx_element_add: symbol not found
+(gst-plugin-scanner:571): GStreamer-WARNING **: Failed to load plugin '/usr/lib/gstreamer-1.0/libgstopengl.so': Error relocating /usr/lib/libgstgl-1.0.so.0: vc_dispmanx_element_add: symbol not found
+
+Upstream-Status: Pending
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+---
+ m4/gst-gl.m4 | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/m4/gst-gl.m4 b/m4/gst-gl.m4
+index 1e97240..ab7774c 100644
+--- a/m4/gst-gl.m4
++++ b/m4/gst-gl.m4
+@@ -231,7 +231,7 @@ case $host in
+                             HAVE_EGL=yes
+                             HAVE_GLES2=yes
+                             HAVE_EGL_RPI=yes
+-                            EGL_LIBS="-lbcm_host -lvcos -lvchiq_arm"
++                            EGL_LIBS="-lbcm_host -lvchostif -lvcos -lvchiq_arm"
+                             EGL_CFLAGS=""
+                             AC_DEFINE(USE_EGL_RPI, [1], [Use RPi platform])
+                           ])
+-- 
+2.7.4
+

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/make-gio_unix_2_0-dependency-configurable.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base/make-gio_unix_2_0-dependency-configurable.patch
@@ -1,0 +1,45 @@
+From 7ffa6e3d00e1d8a060f3f4c2bb9a72691af05d79 Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Wed, 20 Jan 2016 13:00:00 -0800
+Subject: [PATCH] make gio_unix_2_0 dependency configurable
+
+Prior to 1.7.1, gst-plugins-base accepted a configure option to
+disable gio_unix_2_0, however it was implemented incorrectly using
+AG_GST_CHECK_FEATURE. That was fixed in 1.7.1 by making the
+dependency unconditional.
+
+  http://cgit.freedesktop.org/gstreamer/gst-plugins-base/commit/?id=aadefefba88afe4acbe64454650f24e7ce7c8d70
+
+To make builds deterministic, re-instate support for
+--disable-gio_unix_2_0, but implement it using the AC_ARG_ENABLE
+instead of AG_GST_CHECK_FEATURE.
+
+Upstream-Status: Pending
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+
+---
+ configure.ac | 7 +++++++
+ 1 file changed, 7 insertions(+)
+
+diff --git a/configure.ac b/configure.ac
+index 12807bc..35a0bf3 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -806,9 +806,16 @@ AM_CONDITIONAL(HAVE_PNG, test "x$HAVE_PNG" = "xyes")
+ AM_CONDITIONAL(HAVE_JPEG, test "x$HAVE_JPEG" = "xyes")
+ 
+ dnl *** gio-unix-2.0 for tests/check/pipelines/tcp.c ***
++AC_ARG_ENABLE([gio_unix_2_0],
++  [AS_HELP_STRING([--disable-gio_unix_2_0],[disable use of gio_unix_2_0])],
++  [],
++  [enable_gio_unix_2_0=yes])
++
++if test "x${enable_gio_unix_2_0}" != "xno"; then
+ PKG_CHECK_MODULES(GIO_UNIX_2_0, gio-unix-2.0 >= 2.24,
+     HAVE_GIO_UNIX_2_0="yes",
+     HAVE_GIO_UNIX_2_0="no")
++fi
+ AM_CONDITIONAL(USE_GIO_UNIX_2_0, test "x$HAVE_GIO_UNIX_2_0" = "xyes")
+ 
+ dnl *** finalize CFLAGS, LDFLAGS, LIBS

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base_1.14.4.bb
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-base_1.14.4.bb
@@ -1,0 +1,77 @@
+require gstreamer1.0-plugins.inc
+
+LICENSE = "GPLv2+ & LGPLv2+"
+LIC_FILES_CHKSUM = "file://COPYING;md5=c54ce9345727175ff66d17b67ff51f58 \
+                    file://COPYING.LIB;md5=6762ed442b3822387a51c92d928ead0d \
+                    file://common/coverage/coverage-report.pl;beginline=2;endline=17;md5=a4e1830fce078028c8f0974161272607"
+
+SRC_URI = " \
+            http://gstreamer.freedesktop.org/src/gst-plugins-base/gst-plugins-base-${PV}.tar.xz \
+            file://get-caps-from-src-pad-when-query-caps.patch \
+            file://0003-ssaparse-enhance-SSA-text-lines-parsing.patch \
+            file://make-gio_unix_2_0-dependency-configurable.patch \
+            file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
+            file://0001-Makefile.am-don-t-hardcode-libtool-name-when-running.patch \
+            file://0002-Makefile.am-prefix-calls-to-pkg-config-with-PKG_CONF.patch \
+            file://0003-riff-add-missing-include-directories-when-calling-in.patch \
+            file://0004-rtsp-drop-incorrect-reference-to-gstreamer-sdp-in-Ma.patch \
+            file://0009-glimagesink-Downrank-to-marginal.patch \
+            file://0001-gstreamer-gl.pc.in-don-t-append-GL_CFLAGS-to-CFLAGS.patch \
+            file://0010-gl-Add-switch-for-explicitely-enabling-disabling-GBM.patch \
+            file://0011-gl-Add-switches-for-explicitely-enabling-disabling-P.patch \
+            file://link-with-libvchostif.patch \
+            file://CVE-2019-9928.patch \
+            "
+SRC_URI[md5sum] = "4dbe20c1bf44191c2b8833234df5cb2a"
+SRC_URI[sha256sum] = "ca6139490e48863e7706d870ff4e8ac9f417b56f3b9e4b3ce490c13b09a77461"
+
+S = "${WORKDIR}/gst-plugins-base-${PV}"
+
+DEPENDS += "iso-codes util-linux"
+
+inherit gettext gobject-introspection
+
+PACKAGES_DYNAMIC =+ "^libgst.*"
+
+# opengl packageconfig factored out to make it easy for distros
+# and BSP layers to pick either (desktop) opengl, gles2, or no GL
+PACKAGECONFIG_GL ?= "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'gles2 egl', '', d)}"
+
+PACKAGECONFIG ??= " \
+    ${GSTREAMER_ORC} \
+    ${PACKAGECONFIG_GL} \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'alsa x11', d)} \
+    gio-unix-2.0 jpeg ogg pango png theora vorbis zlib \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland egl', '', d)} \
+"
+
+X11DEPENDS = "virtual/libx11 libsm libxrender libxv"
+X11ENABLEOPTS = "--enable-x --enable-xvideo --enable-xshm"
+X11DISABLEOPTS = "--disable-x --disable-xvideo --disable-xshm"
+
+PACKAGECONFIG[alsa]         = "--enable-alsa,--disable-alsa,alsa-lib"
+PACKAGECONFIG[cdparanoia]   = "--enable-cdparanoia,--disable-cdparanoia,cdparanoia"
+PACKAGECONFIG[egl]          = "--enable-egl,--disable-egl,virtual/egl"
+PACKAGECONFIG[gbm]          = "--enable-gbm,--disable-gbm,virtual/libgbm libgudev libdrm"
+PACKAGECONFIG[gio-unix-2.0] = "--enable-gio_unix_2_0,--disable-gio_unix_2_0,glib-2.0"
+PACKAGECONFIG[gles2]        = "--enable-gles2,--disable-gles2,virtual/libgles2"
+PACKAGECONFIG[ivorbis]      = "--enable-ivorbis,--disable-ivorbis,tremor"
+PACKAGECONFIG[jpeg]         = "--enable-jpeg,--disable-jpeg,jpeg"
+PACKAGECONFIG[ogg]          = "--enable-ogg,--disable-ogg,libogg"
+PACKAGECONFIG[opengl]       = "--enable-opengl,--disable-opengl,virtual/libgl libglu"
+PACKAGECONFIG[opus]         = "--enable-opus,--disable-opus,libopus"
+PACKAGECONFIG[pango]        = "--enable-pango,--disable-pango,pango"
+PACKAGECONFIG[png]          = "--enable-png,--disable-png,libpng"
+PACKAGECONFIG[theora]       = "--enable-theora,--disable-theora,libtheora"
+PACKAGECONFIG[visual]       = "--enable-libvisual,--disable-libvisual,libvisual"
+PACKAGECONFIG[vorbis]       = "--enable-vorbis,--disable-vorbis,libvorbis"
+PACKAGECONFIG[x11]          = "${X11ENABLEOPTS},${X11DISABLEOPTS},${X11DEPENDS}"
+PACKAGECONFIG[wayland]      = "--enable-wayland,--disable-wayland,wayland-native wayland wayland-protocols libdrm"
+PACKAGECONFIG[zlib]         = "--enable-zlib,--disable-zlib,zlib"
+
+FILES_${PN}-dev += "${libdir}/gstreamer-${LIBV}/include/gst/gl/gstglconfig.h"
+FILES_${MLPREFIX}libgsttag-1.0 += "${datadir}/gst-plugins-base/1.0/license-translations.dict"
+
+do_compile_prepend() {
+        export GIR_EXTRA_LIBS_PATH="${B}/gst-libs/gst/tag/.libs:${B}/gst-libs/gst/video/.libs:${B}/gst-libs/gst/audio/.libs:${B}/gst-libs/gst/rtp/.libs:${B}/gst-libs/gst/allocators/.libs"
+}

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-good/0001-gstrtpmp4gpay-set-dafault-value-for-MPEG4-without-co.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-good/0001-gstrtpmp4gpay-set-dafault-value-for-MPEG4-without-co.patch
@@ -1,0 +1,62 @@
+From c782a30482908a4b4dd9cd4abff9f9bc4016698f Mon Sep 17 00:00:00 2001
+From: Song Bing <b06498@freescale.com>
+Date: Tue, 5 Aug 2014 14:40:46 +0800
+Subject: [PATCH] gstrtpmp4gpay: set dafault value for MPEG4 without codec
+ data in caps.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=734263
+
+Upstream-Status: Submitted
+
+Signed-off-by: Song Bing <b06498@freescale.com>
+---
+ gst/rtp/gstrtpmp4gpay.c |   19 ++++++++++++++++++-
+ 1 file changed, 18 insertions(+), 1 deletion(-)
+
+diff --git a/gst/rtp/gstrtpmp4gpay.c b/gst/rtp/gstrtpmp4gpay.c
+index 7913d9a..1749d39 100644
+--- a/gst/rtp/gstrtpmp4gpay.c
++++ b/gst/rtp/gstrtpmp4gpay.c
+@@ -391,6 +391,7 @@ gst_rtp_mp4g_pay_setcaps (GstRTPBasePayload * payload, GstCaps * caps)
+   const GValue *codec_data;
+   const gchar *media_type = NULL;
+   gboolean res;
++  const gchar *name;
+ 
+   rtpmp4gpay = GST_RTP_MP4G_PAY (payload);
+ 
+@@ -401,7 +402,6 @@ gst_rtp_mp4g_pay_setcaps (GstRTPBasePayload * payload, GstCaps * caps)
+     GST_LOG_OBJECT (rtpmp4gpay, "got codec_data");
+     if (G_VALUE_TYPE (codec_data) == GST_TYPE_BUFFER) {
+       GstBuffer *buffer;
+-      const gchar *name;
+ 
+       buffer = gst_value_get_buffer (codec_data);
+       GST_LOG_OBJECT (rtpmp4gpay, "configuring codec_data");
+@@ -427,6 +427,23 @@ gst_rtp_mp4g_pay_setcaps (GstRTPBasePayload * payload, GstCaps * caps)
+ 
+       rtpmp4gpay->config = gst_buffer_copy (buffer);
+     }
++  } else {
++    name = gst_structure_get_name (structure);
++
++    if (!strcmp (name, "video/mpeg")) {
++      rtpmp4gpay->profile = g_strdup ("1");
++
++      /* fixed rate */
++      rtpmp4gpay->rate = 90000;
++      /* video stream type */
++      rtpmp4gpay->streamtype = "4";
++      /* no params for video */
++      rtpmp4gpay->params = NULL;
++      /* mode */
++      rtpmp4gpay->mode = "generic";
++
++      media_type = "video";
++    }
+   }
+   if (media_type == NULL)
+     goto config_failed;
+-- 
+1.7.9.5
+

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-good/avoid-including-sys-poll.h-directly.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-good/avoid-including-sys-poll.h-directly.patch
@@ -1,0 +1,44 @@
+From 4bfe2c8570a4a7080ec662504882969054d8a072 Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Wed, 3 Feb 2016 18:12:38 -0800
+Subject: [PATCH] avoid including <sys/poll.h> directly
+
+musl libc generates warnings if <sys/poll.h> is included directly.
+
+Upstream-Status: Pending
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+---
+ ext/raw1394/gstdv1394src.c  | 2 +-
+ ext/raw1394/gsthdv1394src.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/ext/raw1394/gstdv1394src.c b/ext/raw1394/gstdv1394src.c
+index dbc7607..3c42b41 100644
+--- a/ext/raw1394/gstdv1394src.c
++++ b/ext/raw1394/gstdv1394src.c
+@@ -37,7 +37,7 @@
+ #include "config.h"
+ #endif
+ #include <unistd.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <sys/socket.h>
+ #include <errno.h>
+ #include <fcntl.h>
+diff --git a/ext/raw1394/gsthdv1394src.c b/ext/raw1394/gsthdv1394src.c
+index 0b07a37..9785a15 100644
+--- a/ext/raw1394/gsthdv1394src.c
++++ b/ext/raw1394/gsthdv1394src.c
+@@ -36,7 +36,7 @@
+ #include "config.h"
+ #endif
+ #include <unistd.h>
+-#include <sys/poll.h>
++#include <poll.h>
+ #include <sys/socket.h>
+ #include <errno.h>
+ #include <fcntl.h>
+-- 
+1.9.1
+

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-good/ensure-valid-sentinel-for-gst_structure_get.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-good/ensure-valid-sentinel-for-gst_structure_get.patch
@@ -1,0 +1,40 @@
+From 2169f2205c0205a220d826d7573e5a863bd36e0a Mon Sep 17 00:00:00 2001
+From: Andre McCurdy <armccurdy@gmail.com>
+Date: Tue, 9 Feb 2016 14:00:00 -0800
+Subject: [PATCH] ensure valid sentinal for gst_structure_get()
+
+gst_structure_get() is declared with G_GNUC_NULL_TERMINATED, ie
+__attribute__((__sentinel__)), which means gcc will generate a
+warning if the last parameter passed to the function is not NULL
+(where a valid NULL in this context is defined as zero with any
+pointer type).
+
+The C code callers to gst_structure_get() within gst-plugins-good
+use the C NULL definition (ie ((void*)0)), which is a valid sentinel.
+
+However gstid3v2mux.cc uses the C++ NULL definition (ie 0L), which
+is not a valid sentinel without an explicit cast to a pointer type.
+
+Upstream-Status: Pending
+
+Signed-off-by: Andre McCurdy <armccurdy@gmail.com>
+---
+ ext/taglib/gstid3v2mux.cc | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/ext/taglib/gstid3v2mux.cc b/ext/taglib/gstid3v2mux.cc
+index 8651e77..a87234f 100644
+--- a/ext/taglib/gstid3v2mux.cc
++++ b/ext/taglib/gstid3v2mux.cc
+@@ -465,7 +465,7 @@ add_image_tag (ID3v2::Tag * id3v2tag, const GstTagList * list,
+ 
+           if (info_struct) {
+             if (gst_structure_get (info_struct, "image-type",
+-                    GST_TYPE_TAG_IMAGE_TYPE, &image_type, NULL)) {
++                    GST_TYPE_TAG_IMAGE_TYPE, &image_type, (void *) NULL)) {
+               if (image_type > 0 && image_type <= 18) {
+                 image_type += 2;
+               } else {
+-- 
+1.9.1
+

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-good_1.14.4.bb
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-good_1.14.4.bb
@@ -1,0 +1,79 @@
+require gstreamer1.0-plugins.inc
+
+SRC_URI = " \
+            http://gstreamer.freedesktop.org/src/gst-plugins-good/gst-plugins-good-${PV}.tar.xz \
+            file://0001-gstrtpmp4gpay-set-dafault-value-for-MPEG4-without-co.patch \
+            file://avoid-including-sys-poll.h-directly.patch \
+            file://ensure-valid-sentinel-for-gst_structure_get.patch \
+            file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
+            "
+
+SRC_URI[md5sum] = "6e3b247097366cf2639f22abfece7113"
+SRC_URI[sha256sum] = "5f8b553260cb0aac56890053d8511db1528d53cae10f0287cfce2cb2acc70979"
+
+S = "${WORKDIR}/gst-plugins-good-${PV}"
+
+LICENSE = "GPLv2+ & LGPLv2.1+"
+LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
+                    file://common/coverage/coverage-report.pl;beginline=2;endline=17;md5=a4e1830fce078028c8f0974161272607 \
+                    file://gst/replaygain/rganalysis.c;beginline=1;endline=23;md5=b60ebefd5b2f5a8e0cab6bfee391a5fe"
+
+DEPENDS += "gstreamer1.0-plugins-base libcap"
+RPROVIDES_${PN}-pulseaudio += "${PN}-pulse"
+RPROVIDES_${PN}-soup += "${PN}-souphttpsrc"
+
+inherit gettext
+
+PACKAGECONFIG ??= " \
+    ${GSTREAMER_ORC} \
+    ${@bb.utils.filter('DISTRO_FEATURES', 'pulseaudio x11', d)} \
+    bz2 cairo flac gdk-pixbuf gudev jpeg lame libpng mpg123 soup speex taglib v4l2 zlib \
+"
+
+X11DEPENDS = "virtual/libx11 libsm libxrender libxfixes libxdamage"
+
+PACKAGECONFIG[bz2]        = "--enable-bz2,--disable-bz2,bzip2"
+PACKAGECONFIG[cairo]      = "--enable-cairo,--disable-cairo,cairo"
+PACKAGECONFIG[dv1394]     = "--enable-dv1394,--disable-dv1394,libiec61883 libavc1394 libraw1394"
+PACKAGECONFIG[flac]       = "--enable-flac,--disable-flac,flac"
+PACKAGECONFIG[gdk-pixbuf] = "--enable-gdk_pixbuf,--disable-gdk_pixbuf,gdk-pixbuf"
+PACKAGECONFIG[gtk]        = "--enable-gtk3,--disable-gtk3,gtk+3"
+PACKAGECONFIG[gudev]      = "--with-gudev,--without-gudev,libgudev"
+PACKAGECONFIG[jack]       = "--enable-jack,--disable-jack,jack"
+PACKAGECONFIG[jpeg]       = "--enable-jpeg,--disable-jpeg,jpeg"
+PACKAGECONFIG[lame]       = "--enable-lame,--disable-lame,lame"
+PACKAGECONFIG[libpng]     = "--enable-libpng,--disable-libpng,libpng"
+PACKAGECONFIG[libv4l2]    = "--with-libv4l2,--without-libv4l2,v4l-utils"
+PACKAGECONFIG[mpg123]     = "--enable-mpg123,--disable-mpg123,mpg123"
+PACKAGECONFIG[pulseaudio] = "--enable-pulse,--disable-pulse,pulseaudio"
+PACKAGECONFIG[soup]       = "--enable-soup,--disable-soup,libsoup-2.4"
+PACKAGECONFIG[speex]      = "--enable-speex,--disable-speex,speex"
+PACKAGECONFIG[taglib]     = "--enable-taglib,--disable-taglib,taglib"
+PACKAGECONFIG[v4l2]       = "--enable-gst_v4l2 --enable-v4l2-probe,--disable-gst_v4l2"
+PACKAGECONFIG[vpx]        = "--enable-vpx,--disable-vpx,libvpx"
+PACKAGECONFIG[wavpack]    = "--enable-wavpack,--disable-wavpack,wavpack"
+PACKAGECONFIG[x11]        = "--enable-x,--disable-x,${X11DEPENDS}"
+PACKAGECONFIG[zlib]       = "--enable-zlib,--disable-zlib,zlib"
+
+# qt5 support is disabled, because it is not present in OE core, and requires more work than
+# just adding a packageconfig (it requires access to moc, uic, rcc, and qmake paths).
+# This is better done in a separate qt5 layer (which then should add a "qt5" packageconfig
+# in a gstreamer1.0-plugins-good bbappend).
+
+EXTRA_OECONF += " \
+    --enable-oss \
+    --disable-aalib \
+    --disable-aalibtest \
+    --disable-directsound \
+    --disable-libcaca \
+    --disable-libdv \
+    --disable-oss4 \
+    --disable-osx_audio \
+    --disable-osx_video \
+    --disable-qt \
+    --disable-shout2 \
+    --disable-twolame \
+    --disable-waveform \
+"
+
+FILES_${PN}-equalizer += "${datadir}/gstreamer-1.0/presets/*.prs"

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-ugly_1.14.4.bb
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins-ugly_1.14.4.bb
@@ -1,0 +1,40 @@
+require gstreamer1.0-plugins.inc
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=a6f89e2100d9b6cdffcea4f398e37343 \
+                    file://tests/check/elements/xingmux.c;beginline=1;endline=21;md5=4c771b8af188724855cb99cadd390068"
+
+LICENSE = "GPLv2+ & LGPLv2.1+ & LGPLv2+"
+LICENSE_FLAGS = "commercial"
+
+SRC_URI = " \
+            http://gstreamer.freedesktop.org/src/gst-plugins-ugly/gst-plugins-ugly-${PV}.tar.xz \
+            file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
+            "
+SRC_URI[md5sum] = "90768a0074db071175ce980064d9a1ac"
+SRC_URI[sha256sum] = "ac02d837f166c35ff6ce0738e281680d0b90052cfb1f0255dcf6aaca5f0f6d23"
+
+S = "${WORKDIR}/gst-plugins-ugly-${PV}"
+
+DEPENDS += "gstreamer1.0-plugins-base"
+
+inherit gettext
+
+PACKAGECONFIG ??= " \
+    ${GSTREAMER_ORC} \
+    a52dec mpeg2dec \
+"
+
+PACKAGECONFIG[a52dec]   = "--enable-a52dec,--disable-a52dec,liba52"
+PACKAGECONFIG[amrnb]    = "--enable-amrnb,--disable-amrnb,opencore-amr"
+PACKAGECONFIG[amrwb]    = "--enable-amrwb,--disable-amrwb,opencore-amr"
+PACKAGECONFIG[cdio]     = "--enable-cdio,--disable-cdio,libcdio"
+PACKAGECONFIG[dvdread]  = "--enable-dvdread,--disable-dvdread,libdvdread"
+PACKAGECONFIG[mpeg2dec] = "--enable-mpeg2dec,--disable-mpeg2dec,mpeg2dec"
+PACKAGECONFIG[x264]     = "--enable-x264,--disable-x264,x264"
+
+EXTRA_OECONF += " \
+    --disable-sidplay \
+"
+
+FILES_${PN}-amrnb += "${datadir}/gstreamer-1.0/presets/GstAmrnbEnc.prs"
+FILES_${PN}-x264 += "${datadir}/gstreamer-1.0/presets/GstX264Enc.prs"

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins.inc
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-plugins.inc
@@ -1,0 +1,41 @@
+SUMMARY = "Plugins for the GStreamer multimedia framework 1.x"
+HOMEPAGE = "http://gstreamer.freedesktop.org/"
+BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
+SECTION = "multimedia"
+
+DEPENDS = "gstreamer1.0 glib-2.0-native"
+
+SRC_URI_append = " file://gtk-doc-tweaks.patch"
+
+inherit autotools pkgconfig upstream-version-is-even gtk-doc
+
+acpaths = "-I ${S}/common/m4 -I ${S}/m4"
+
+LIBV = "1.0"
+require gst-plugins-package.inc
+
+# Orc enables runtime JIT compilation of data processing routines from Orc
+# bytecode to SIMD instructions for various architectures (currently SSE, MMX,
+# MIPS, Altivec and NEON are supported).
+
+GSTREAMER_ORC ?= "orc"
+
+PACKAGECONFIG[debug] = "--enable-debug,--disable-debug"
+PACKAGECONFIG[orc] = "--enable-orc,--disable-orc,orc orc-native"
+PACKAGECONFIG[valgrind] = "--enable-valgrind,--disable-valgrind,valgrind"
+
+export ORCC = "${STAGING_DIR_NATIVE}${bindir}/orcc"
+
+EXTRA_OECONF = " \
+    --disable-examples \
+"
+
+delete_pkg_m4_file() {
+	# This m4 file is out of date and is missing PKG_CONFIG_SYSROOT_PATH tweaks which we need for introspection
+	rm "${S}/common/m4/pkg.m4" || true
+	rm -f "${S}/common/m4/gtk-doc.m4"
+}
+
+do_configure[prefuncs] += " delete_pkg_m4_file"
+
+PACKAGES_DYNAMIC = "^${PN}-.*"

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-python_1.14.4.bb
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-python_1.14.4.bb
@@ -1,0 +1,43 @@
+SUMMARY = "Python bindings for GStreamer 1.0"
+HOMEPAGE = "http://cgit.freedesktop.org/gstreamer/gst-python/"
+SECTION = "multimedia"
+
+LICENSE = "LGPLv2.1"
+LIC_FILES_CHKSUM = "file://COPYING;md5=c34deae4e395ca07e725ab0076a5f740"
+
+SRC_URI = "http://gstreamer.freedesktop.org/src/${PNREAL}/${PNREAL}-${PV}.tar.xz"
+SRC_URI[md5sum] = "d4c0e3915f547feef49208ee08981e5a"
+SRC_URI[sha256sum] = "d0fdb24f93b6d889f309d2f526b8ea9577e0084ff0a62b4623ef1aed52e85a1b"
+
+DEPENDS = "gstreamer1.0 python3-pygobject"
+RDEPENDS_${PN} += "gstreamer1.0 python3-pygobject"
+
+PNREAL = "gst-python"
+
+S = "${WORKDIR}/${PNREAL}-${PV}"
+
+# gobject-introspection is mandatory and cannot be configured
+REQUIRED_DISTRO_FEATURES = "gobject-introspection-data"
+UNKNOWN_CONFIGURE_WHITELIST_append = " --enable-introspection --disable-introspection"
+
+inherit autotools pkgconfig distutils3-base upstream-version-is-even gobject-introspection distro_features_check
+
+do_install_append() {
+    # gstpythonplugin hardcodes the location of the libpython from the build
+    # workspace and then fails at runtime. We can override it using
+    # --with-libpython-dir=${libdir}, but it still fails because it looks for a
+    # symlinked library ending in .so instead of the actually library with
+    # LIBNAME.so.MAJOR.MINOR. Although we could patch the code to use the path
+    # we want, it will break again if the library version ever changes. We need
+    # to think about the best way of handling this and possibly consult
+    # upstream.
+    #
+    # Note that this particular find line is taken from the Debian packaging for
+    # gst-python1.0.
+    find "${D}" \
+        -name '*.pyc' -o \
+        -name '*.pyo' -o \
+        -name '*.la' -o \
+        -name 'libgstpythonplugin*' \
+        -delete
+}

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-rtsp-server/0001-Don-t-hardcode-libtool-name-when-using-introspection.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-rtsp-server/0001-Don-t-hardcode-libtool-name-when-using-introspection.patch
@@ -1,0 +1,27 @@
+From 4a12569e5ae5be63cd92a9b178860026a99746b1 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Tue, 27 Oct 2015 16:55:45 +0200
+Subject: [PATCH] Don't hardcode libtool name when using introspection
+
+Upstream-Status: Pending [review on oe-core maillist]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ gst/rtsp-server/Makefile.am | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/gst/rtsp-server/Makefile.am b/gst/rtsp-server/Makefile.am
+index 4fcd366..c67f5ab 100644
+--- a/gst/rtsp-server/Makefile.am
++++ b/gst/rtsp-server/Makefile.am
+@@ -87,7 +87,7 @@ GstRtspServer-@GST_API_VERSION@.gir: $(INTROSPECTION_SCANNER) libgstrtspserver-@
+ 		--include=Gst-@GST_API_VERSION@ \
+ 		--include=GstRtsp-@GST_API_VERSION@ \
+ 		--include=GstNet-@GST_API_VERSION@ \
+-		--libtool="$(top_builddir)/libtool" \
++		--libtool="$(LIBTOOL)" \
+ 		--pkg gstreamer-@GST_API_VERSION@ \
+ 		--pkg gstreamer-rtsp-@GST_API_VERSION@ \
+ 		--pkg gstreamer-net-@GST_API_VERSION@ \
+-- 
+2.1.4
+

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-rtsp-server_1.14.4.bb
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-rtsp-server_1.14.4.bb
@@ -1,0 +1,35 @@
+SUMMARY = "A library on top of GStreamer for building an RTSP server"
+HOMEPAGE = "http://cgit.freedesktop.org/gstreamer/gst-rtsp-server/"
+SECTION = "multimedia"
+LICENSE = "LGPLv2"
+LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d"
+
+DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base"
+
+PNREAL = "gst-rtsp-server"
+
+SRC_URI = "http://gstreamer.freedesktop.org/src/${PNREAL}/${PNREAL}-${PV}.tar.xz \
+           file://0001-Don-t-hardcode-libtool-name-when-using-introspection.patch \
+           file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
+           file://gtk-doc-tweaks.patch \
+           "
+
+SRC_URI[md5sum] = "ab0fb5c829266a500e14b46b7bdf06bf"
+SRC_URI[sha256sum] = "3d0ece2afdcd601c175ece24e32a30bc19247b454f4eafd3deeec2533c6884f1"
+
+S = "${WORKDIR}/${PNREAL}-${PV}"
+
+inherit autotools pkgconfig upstream-version-is-even gobject-introspection gtk-doc
+
+EXTRA_OECONF = "--disable-examples --disable-tests"
+
+# Starting with 1.8.0 gst-rtsp-server includes dependency-less plugins as well
+LIBV = "1.0"
+require gst-plugins-package.inc
+
+delete_pkg_m4_file() {
+        # This m4 file is out of date and is missing PKG_CONFIG_SYSROOT_PATH tweaks which we need for introspection
+        rm "${S}/common/m4/pkg.m4" || true
+}
+
+do_configure[prefuncs] += " delete_pkg_m4_file"

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-vaapi/0001-gst-vaapi-Makefile.am-Add-EGL_CFLAGS-to-libgstvaapi-.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-vaapi/0001-gst-vaapi-Makefile.am-Add-EGL_CFLAGS-to-libgstvaapi-.patch
@@ -1,0 +1,33 @@
+From 5403a89e6a7ac72a23e0221075c0c19b5f85a021 Mon Sep 17 00:00:00 2001
+From: Fabio Berton <fabio.berton@ossystems.com.br>
+Date: Wed, 13 Jun 2018 09:09:25 -0300
+Subject: [PATCH] gst/vaapi/Makefile.am: Add EGL_CFLAGS to libgstvaapi CFLAGS
+Organization: O.S. Systems Software LTDA.
+
+We need this to pass correctly EGL CFLAGS when building with EGL support.
+
+Upstream-Status: Pending
+
+Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>
+---
+ gst/vaapi/Makefile.am | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/gst/vaapi/Makefile.am b/gst/vaapi/Makefile.am
+index b299ac98..d6cab71f 100644
+--- a/gst/vaapi/Makefile.am
++++ b/gst/vaapi/Makefile.am
+@@ -24,6 +24,10 @@ libgstvaapi_LIBS += $(top_builddir)/gst-libs/gst/vaapi/libgstvaapi-glx.la
+ endif
+ 
+ if USE_EGL
++libgstvaapi_CFLAGS += \
++	$(EGL_CFLAGS)	\
++	$(NULL)
++
+ libgstvaapi_LIBS += $(top_builddir)/gst-libs/gst/vaapi/libgstvaapi-egl.la
+ endif
+ 
+-- 
+2.17.1
+

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-vaapi/0001-libs-decoder-release-VA-buffers-after-vaEndPicture.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-vaapi/0001-libs-decoder-release-VA-buffers-after-vaEndPicture.patch
@@ -1,0 +1,45 @@
+From bb8894aaf934b3af4d44cf54e860510fe4d615b3 Mon Sep 17 00:00:00 2001
+From: Tianhao Liu <tianhao.liu@intel.com>
+Date: Thu, 7 Jun 2018 09:34:11 +0800
+Subject: [PATCH] libs: decoder: release VA buffers after vaEndPicture
+
+This change is due a problem decoding JPEGs with Intel's media-driver:
+no image was generated.
+
+This patch relases the VA buffers after vaEndPicture() is called,
+and not before (after vaRenderPicture()).
+
+https://bugzilla.gnome.org/show_bug.cgi?id=796505
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/gstreamer/gstreamer-vaapi/commit/bb8894aaf934b3af4d44cf54e860510fe4d615b3]
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+---
+ gst-libs/gst/vaapi/gstvaapidecoder_objects.c | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/gst-libs/gst/vaapi/gstvaapidecoder_objects.c b/gst-libs/gst/vaapi/gstvaapidecoder_objects.c
+index 20d4f55..2dd4c27 100644
+--- a/gst-libs/gst/vaapi/gstvaapidecoder_objects.c
++++ b/gst-libs/gst/vaapi/gstvaapidecoder_objects.c
+@@ -304,12 +304,17 @@ gst_vaapi_picture_decode (GstVaapiPicture * picture)
+     status = vaRenderPicture (va_display, va_context, va_buffers, 2);
+     if (!vaapi_check_status (status, "vaRenderPicture()"))
+       return FALSE;
++  }
++
++  status = vaEndPicture (va_display, va_context);
++
++  for (i = 0; i < picture->slices->len; i++) {
++    GstVaapiSlice *const slice = g_ptr_array_index (picture->slices, i);
+ 
+     vaapi_destroy_buffer (va_display, &slice->param_id);
+     vaapi_destroy_buffer (va_display, &slice->data_id);
+   }
+ 
+-  status = vaEndPicture (va_display, va_context);
+   if (!vaapi_check_status (status, "vaEndPicture()"))
+     return FALSE;
+   return TRUE;
+-- 
+2.7.4
+

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-vaapi/0001-libs-encoder-jpeg-set-component-id-and-Tqi.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-vaapi/0001-libs-encoder-jpeg-set-component-id-and-Tqi.patch
@@ -1,0 +1,65 @@
+From f5eb4faa5914f3745820e557ac2401a7d738be66 Mon Sep 17 00:00:00 2001
+From: Tianhao Liu <tianhao.liu@intel.com>
+Date: Wed, 4 Jul 2018 12:51:10 +0800
+Subject: [PATCH] libs: encoder: jpeg: set component id and Tqi
+
+This change is due a problem encoding JPEGs with Intel's
+media-driver: green/black image when playback jpeg
+
+This patch sets component identifier and quantization table
+destination selector in frame header to support packing headers
+by Intel's media-driver that does not accept packed header
+in AP level.
+
+https://bugzilla.gnome.org/show_bug.cgi?id=796705
+
+Upstream-Status: Backport [https://gitlab.freedesktop.org/gstreamer/gstreamer-vaapi/commit/f5eb4faa5914f3745820e557ac2401a7d738be66]
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+---
+ gst-libs/gst/vaapi/gstvaapiencoder_jpeg.c | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/gst-libs/gst/vaapi/gstvaapiencoder_jpeg.c b/gst-libs/gst/vaapi/gstvaapiencoder_jpeg.c
+index b3f409d..8491fbc 100644
+--- a/gst-libs/gst/vaapi/gstvaapiencoder_jpeg.c
++++ b/gst-libs/gst/vaapi/gstvaapiencoder_jpeg.c
+@@ -205,6 +205,7 @@ fill_picture (GstVaapiEncoderJpeg * encoder,
+     GstVaapiEncPicture * picture,
+     GstVaapiCodedBuffer * codedbuf, GstVaapiSurfaceProxy * surface)
+ {
++  guint i;
+   VAEncPictureParameterBufferJPEG *const pic_param = picture->param;
+ 
+   memset (pic_param, 0, sizeof (VAEncPictureParameterBufferJPEG));
+@@ -224,6 +225,11 @@ fill_picture (GstVaapiEncoderJpeg * encoder,
+   pic_param->num_scan = 1;
+   pic_param->num_components = encoder->n_components;
+   pic_param->quality = encoder->quality;
++  for (i = 0; i < pic_param->num_components; i++) {
++    pic_param->component_id[i] = i + 1;
++    if (i != 0)
++      pic_param->quantiser_table_selector[i] = 1;
++  }
+   return TRUE;
+ }
+ 
+@@ -437,13 +443,11 @@ generate_frame_hdr (GstJpegFrameHdr * frame_hdr, GstVaapiEncoderJpeg * encoder,
+   frame_hdr->num_components = pic_param->num_components;
+ 
+   for (i = 0; i < frame_hdr->num_components; i++) {
+-    frame_hdr->components[i].identifier = i + 1;
++    frame_hdr->components[i].identifier = pic_param->component_id[i];
+     frame_hdr->components[i].horizontal_factor = encoder->h_samp[i];
+     frame_hdr->components[i].vertical_factor = encoder->v_samp[i];
+-    if (i == 0)
+-      frame_hdr->components[i].quant_table_selector = 0;
+-    else
+-      frame_hdr->components[i].quant_table_selector = 1;
++    frame_hdr->components[i].quant_table_selector =
++        pic_param->quantiser_table_selector[i];
+   }
+ }
+ 
+-- 
+2.7.4
+

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-vaapi/0001-vaapsink-downgrade-to-marginal.patch
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-vaapi/0001-vaapsink-downgrade-to-marginal.patch
@@ -1,0 +1,46 @@
+From 0c28cf7bfa90f8947833722cddf23d513490c6c3 Mon Sep 17 00:00:00 2001
+From: Anuj Mittal <anuj.mittal@intel.com>
+Date: Wed, 28 Nov 2018 15:08:48 +0800
+Subject: [PATCH] vaapsink: downgrade to marginal
+
+Using vaapisink with default poky configuration results in an
+unresponsive display as of today because DRI2 rendering is currently broken
+in non composited environments [1] and libva doesn't support DRI3 [2].
+
+Downgrade vaapisink to marginal for now so playbin (and in turn gst-play
+and gtk-play examples) use xvimagesink or others out of box.
+
+[1] https://gitlab.freedesktop.org/xorg/xserver/issues/13
+[2] https://github.com/intel/libva/issues/122
+
+Upstream-Status: Pending
+
+Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
+---
+ gst/vaapi/gstvaapi.c | 6 +-----
+ 1 file changed, 1 insertion(+), 5 deletions(-)
+
+diff --git a/gst/vaapi/gstvaapi.c b/gst/vaapi/gstvaapi.c
+index 9a82454..4d94f2b 100644
+--- a/gst/vaapi/gstvaapi.c
++++ b/gst/vaapi/gstvaapi.c
+@@ -210,7 +210,6 @@ plugin_init (GstPlugin * plugin)
+ {
+   GstVaapiDisplay *display;
+   GArray *decoders;
+-  guint rank;
+ 
+   plugin_add_dependencies (plugin);
+ 
+@@ -235,10 +234,7 @@ plugin_init (GstPlugin * plugin)
+   gst_element_register (plugin, "vaapidecodebin",
+       GST_RANK_PRIMARY + 2, GST_TYPE_VAAPI_DECODE_BIN);
+ 
+-  rank = GST_RANK_PRIMARY;
+-  if (g_getenv ("WAYLAND_DISPLAY"))
+-    rank = GST_RANK_MARGINAL;
+-  gst_element_register (plugin, "vaapisink", rank, GST_TYPE_VAAPISINK);
++  gst_element_register (plugin, "vaapisink", GST_RANK_MARGINAL, GST_TYPE_VAAPISINK);
+ 
+ #if USE_ENCODERS
+   gst_vaapiencode_register (plugin, display);

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0-vaapi_1.14.4.bb
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0-vaapi_1.14.4.bb
@@ -1,0 +1,51 @@
+SUMMARY = "VA-API support to GStreamer"
+DESCRIPTION = "gstreamer-vaapi consists of a collection of VA-API \
+based plugins for GStreamer and helper libraries: `vaapidecode', \
+`vaapiconvert', and `vaapisink'."
+
+REALPN = "gstreamer-vaapi"
+
+LICENSE = "LGPLv2.1+"
+LIC_FILES_CHKSUM = "file://COPYING.LIB;md5=4fbd65380cdd255951079008b364516c"
+
+SRC_URI = "https://gstreamer.freedesktop.org/src/${REALPN}/${REALPN}-${PV}.tar.xz \
+           file://0001-gst-vaapi-Makefile.am-Add-EGL_CFLAGS-to-libgstvaapi-.patch \
+           file://0001-vaapsink-downgrade-to-marginal.patch \
+           file://0001-libs-encoder-jpeg-set-component-id-and-Tqi.patch \
+           file://0001-libs-decoder-release-VA-buffers-after-vaEndPicture.patch \
+           "
+
+SRC_URI[md5sum] = "2fae3442f5f23e7354a0c592bc7b9065"
+SRC_URI[sha256sum] = "ce18dbfe961c6a8d31270231686075586bf7a7df62b778c8e7f5ec148251d0a3"
+
+S = "${WORKDIR}/${REALPN}-${PV}"
+DEPENDS = "libva gstreamer1.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-bad"
+
+inherit autotools pkgconfig gtk-doc distro_features_check upstream-version-is-even
+
+REQUIRED_DISTRO_FEATURES ?= "opengl"
+
+PACKAGES =+ "${PN}-tests"
+
+# OpenGL packageconfig factored out to make it easy for distros
+# and BSP layers to pick either glx, egl, or no GL. By default,
+# try detecting X11 first, and if found (with OpenGL), use GLX,
+# otherwise try to check if EGL can be used.
+PACKAGECONFIG_GL ?= "${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'glx', \
+                        bb.utils.contains('DISTRO_FEATURES',     'opengl', 'egl', \
+                                                                       '', d), d)}"
+
+PACKAGECONFIG ??= "drm \
+                   ${PACKAGECONFIG_GL} \
+                   ${@bb.utils.filter('DISTRO_FEATURES', 'wayland x11', d)}"
+
+PACKAGECONFIG[drm] = "--enable-drm,--disable-drm,udev libdrm"
+PACKAGECONFIG[egl] = "--enable-egl,--disable-egl,virtual/egl"
+PACKAGECONFIG[glx] = "--enable-glx,--disable-glx,virtual/libgl"
+PACKAGECONFIG[wayland] = "--enable-wayland,--disable-wayland,wayland"
+PACKAGECONFIG[x11] = "--enable-x11,--disable-x11,virtual/libx11 libxrandr libxrender"
+
+FILES_${PN} += "${libdir}/gstreamer-*/*.so"
+FILES_${PN}-dbg += "${libdir}/gstreamer-*/.debug"
+FILES_${PN}-dev += "${libdir}/gstreamer-*/*.la ${libdir}/gstreamer-*/*.a"
+FILES_${PN}-tests = "${bindir}/*"

--- a/recipes-multimedia/gstreamer-base/gstreamer1.0_1.14.4.bb
+++ b/recipes-multimedia/gstreamer-base/gstreamer1.0_1.14.4.bb
@@ -1,0 +1,91 @@
+SUMMARY = "GStreamer 1.0 multimedia framework"
+DESCRIPTION = "GStreamer is a multimedia framework for encoding and decoding video and sound. \
+It supports a wide range of formats including mp3, ogg, avi, mpeg and quicktime."
+HOMEPAGE = "http://gstreamer.freedesktop.org/"
+BUGTRACKER = "https://bugzilla.gnome.org/enter_bug.cgi?product=Gstreamer"
+SECTION = "multimedia"
+LICENSE = "LGPLv2+"
+
+DEPENDS = "glib-2.0 glib-2.0-native libcap libxml2 bison-native flex-native"
+
+inherit autotools pkgconfig gettext upstream-version-is-even gobject-introspection gtk-doc ptest
+
+# This way common/m4/introspection.m4 will come first
+# (it has a custom INTROSPECTION_INIT macro, and so must be used instead of our common introspection.m4 file)
+acpaths = "-I ${S}/common/m4 -I ${S}/m4"
+
+LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d \
+                    file://gst/gst.h;beginline=1;endline=21;md5=e059138481205ee2c6fc1c079c016d0d"
+
+S = "${WORKDIR}/gstreamer-${PV}"
+
+SRC_URI = " \
+    http://gstreamer.freedesktop.org/src/gstreamer/gstreamer-${PV}.tar.xz \
+    file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch \
+    file://gtk-doc-tweaks.patch \
+    file://0001-gst-gstpluginloader.c-when-env-var-is-set-do-not-fal.patch \
+    file://add-a-target-to-compile-tests.patch \
+    file://0002-gstconfig.h.in-initial-RISC-V-support.patch \
+    file://run-ptest \
+"
+SRC_URI[md5sum] = "f67fbbc42bd85a0701df119f52fb52bd"
+SRC_URI[sha256sum] = "f94f6696c5f05a3b3a9183e39c5f5c0b779f75a04c0efa497e7920afa985ffc7"
+
+PACKAGECONFIG ??= "${@bb.utils.contains('PTEST_ENABLED', '1', 'tests', '', d)} \
+                   "
+
+PACKAGECONFIG[debug] = "--enable-debug,--disable-debug"
+PACKAGECONFIG[tests] = "--enable-tests,--disable-tests"
+PACKAGECONFIG[valgrind] = "--enable-valgrind,--disable-valgrind,valgrind,"
+PACKAGECONFIG[gst-tracer-hooks] = "--enable-gst-tracer-hooks,--disable-gst-tracer-hooks,"
+PACKAGECONFIG[unwind] = "--with-unwind,--without-unwind,libunwind"
+PACKAGECONFIG[dw] = "--with-dw,--without-dw,elfutils"
+
+EXTRA_OECONF = " \
+    --disable-examples \
+"
+
+CACHED_CONFIGUREVARS += "ac_cv_header_valgrind_valgrind_h=no"
+
+# musl libc generates warnings if <sys/poll.h> is included directly
+CACHED_CONFIGUREVARS += "ac_cv_header_sys_poll_h=no"
+
+PACKAGES += "${PN}-bash-completion"
+
+FILES_${PN} += "${libdir}/gstreamer-1.0/*.so"
+FILES_${PN}-dev += "${libdir}/gstreamer-1.0/*.la ${libdir}/gstreamer-1.0/*.a ${libdir}/gstreamer-1.0/include"
+FILES_${PN}-bash-completion += "${datadir}/bash-completion/completions/ ${datadir}/bash-completion/helpers/gst*"
+
+RDEPENDS_${PN}-ptest += "make"
+
+delete_pkg_m4_file() {
+        # This m4 file is out of date and is missing PKG_CONFIG_SYSROOT_PATH tweaks which we need for introspection
+        rm "${S}/common/m4/pkg.m4" || true
+        rm -f "${S}/common/m4/gtk-doc.m4"
+}
+
+do_configure[prefuncs] += "delete_pkg_m4_file"
+
+do_compile_prepend() {
+        export GIR_EXTRA_LIBS_PATH="${B}/gst/.libs:${B}/libs/gst/base/.libs"
+}
+
+do_compile_ptest() {
+        oe_runmake build-checks
+}
+
+do_install_ptest() {
+        oe_runmake -C tests/check DESTDIR=${D}${PTEST_PATH} install-ptest
+        install -m 644 ${B}/tests/check/Makefile ${D}${PTEST_PATH}
+        install -m 755 ${S}/test-driver ${D}${PTEST_PATH}
+        sed -e 's,--sysroot=${STAGING_DIR_TARGET},,g' \
+            -e 's|${DEBUG_PREFIX_MAP}||g' \
+            -e 's:${HOSTTOOLS_DIR}/::g' \
+            -e 's:${RECIPE_SYSROOT_NATIVE}::g' \
+            -e 's:${BASE_WORKDIR}/${MULTIMACH_TARGET_SYS}::g' \-e 's/^Makefile:/_Makefile:/' \
+            -e 's/^srcdir = \(.*\)/srcdir = ./' -e 's/^top_srcdir = \(.*\)/top_srcdir = ./' \
+            -e 's/^builddir = \(.*\)/builddir = ./' -e 's/^top_builddir = \(.*\)/top_builddir = ./' \
+            -i ${D}${PTEST_PATH}/Makefile
+}
+
+CVE_PRODUCT = "gstreamer"


### PR DESCRIPTION
Jetpack 4.4 uses by default GStreamer therefore when using Deepstream Docker
it requests the host plugins built with 1.14, however Dunfell branch uses GStreamer
1.16.